### PR TITLE
Values and mirror

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,3 +23,13 @@ jobs:
         uses: helm/chart-releaser-action@v1.1.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Push to StormForge Registry
+        env:
+          HELM_REPO_USERNAME: "robot$thestormforge"
+          HELM_REPO_PASSWORD: "${{ secrets.REGISTRY_TOKEN }}"
+        run: |
+          helm plugin install https://github.com/chartmuseum/helm-push
+          helm repo add stormforge https://registry.stormforge.io/chartrepo/library/
+          find ".cr-release-packages" -name "*.tgz" \
+            -execdir helm cm-push "{}" "stormforge" \;

--- a/README.md
+++ b/README.md
@@ -3,15 +3,15 @@
 ## How do I use this chart repository?
 
 ```shell
-helm repo add stormforge https://thestormforge.github.io/helm-charts/
+helm repo add stormforge https://registry.stormforge.io/chartrepo/library/
 ```
 
 For additional instructions, view the [repository home page](https://thestormforge.github.io/helm-charts/).
 
 ## Development
 
-This repository contains a `main` branch and a `gh-pages` branch: the `main` branch contains the source for the latest (potentially unreleased) version of the chart; the `gh-pages` branch contains the actual Helm repository.
+This repository contains a `main` branch and a `gh-pages` branch: the `main` branch contains the source for the latest (potentially unreleased) version of the chart; the `gh-pages` branch contains a mirror of the Helm repository.
 
-The [Helm Chart Releaser](https://github.com/marketplace/actions/helm-chart-releaser) Action to keep the the Helm repository on the `gh-pages` branch up to date.
+The [Helm Chart Releaser](https://github.com/marketplace/actions/helm-chart-releaser) Action is used to keep the the Helm repository on the `gh-pages` branch up to date.
 
-There is a [Build](https://github.com/thestormforge/helm-charts/actions/workflows/build.yaml) Action that can be used to refresh the chart (it can be run manually or triggered from another repository).
+There is a [Build](https://github.com/thestormforge/helm-charts/actions/workflows/build.yaml) Action that can be used to refresh the Optimize Pro chart (it can be run manually or triggered from another repository).

--- a/charts/optimize-live/Chart.yaml
+++ b/charts/optimize-live/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/optimize-live/templates/_helpers.tpl
+++ b/charts/optimize-live/templates/_helpers.tpl
@@ -89,14 +89,12 @@ Create the name of the rolebinding to use
 Create the image pull secret
 */}}
 {{- define "optimize-live.dockerConfig" -}}
-{{- if .Values.imageCredentials.create }}
-{{- $auths := printf "%s:%s" .Values.imageCredentials.Username .Values.imageCredentials.password -}}
+{{- $auths := printf "%s:%s" .Values.imageCredentials.username .Values.imageCredentials.password -}}
 {{- $authsB64 := b64enc $auths -}}
 {{- $dockerAuth := dict "username" .Values.imageCredentials.username "password" .Values.imageCredentials.password "auths" $authsB64 -}}
 {{- $registry := dict .Values.imageCredentials.registry $dockerAuth -}}
 {{- $dockerAuths := dict "auths" $registry -}}
 {{ b64enc (toJson $dockerAuths) }}
-{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/optimize-live/templates/secret.yaml
+++ b/charts/optimize-live/templates/secret.yaml
@@ -9,6 +9,5 @@ metadata:
 data:
   STORMFORGE_AUTHORIZATION_CLIENT_ID: {{ .Values.authorization.clientID | b64enc }}
   STORMFORGE_AUTHORIZATION_CLIENT_SECRET: {{ .Values.authorization.clientSecret | b64enc }}
-  STORMFORGE_SERVER_IDENTIFIER: {{ .Values.authorization.serverIdentifier | b64enc }}
-  STORMFORGE_SERVER_ISSUER: {{ .Values.authorization.serverIssuer | b64enc }}
-  STORMFORGE_TOKEN_ENDPOINT: {{ .Values.authorization.tokenEndpoint | b64enc }}
+  STORMFORGE_SERVER_IDENTIFIER: {{ .Values.stormforge.address | b64enc }}
+  STORMFORGE_SERVER_ISSUER: {{ .Values.authorization.issuer | b64enc }}

--- a/charts/optimize-live/templates/secret.yaml
+++ b/charts/optimize-live/templates/secret.yaml
@@ -11,3 +11,6 @@ data:
   STORMFORGE_AUTHORIZATION_CLIENT_SECRET: {{ .Values.authorization.clientSecret | b64enc }}
   STORMFORGE_SERVER_IDENTIFIER: {{ .Values.stormforge.address | b64enc }}
   STORMFORGE_SERVER_ISSUER: {{ .Values.authorization.issuer | b64enc }}
+  {{- range .Values.extraEnvVars }}
+  {{ .name }}: {{ .value | b64enc }}
+  {{- end }}

--- a/charts/optimize-live/values.yaml
+++ b/charts/optimize-live/values.yaml
@@ -50,17 +50,17 @@ rbac:
     name: ""
 
 imageCredentials:
-  create: true
-  password: password
   registry: registry.stormforge.io
   username: username
+  password: password
+
+stormforge:
+  address: https://api.stormforge.io/
 
 authorization:
+  issuer: https://api.stormforge.io/
   clientID: id
   clientSecret: secret
-  serverIdentifier: https://api.stormforge.io/
-  serverIssuer: https://api.stormforge.io/
-  tokenEndpoint: https://auth.stormforge.io/oauth/token
 
 metricsURL: http://prometheus:9090
 

--- a/charts/optimize-live/values.yaml
+++ b/charts/optimize-live/values.yaml
@@ -71,6 +71,8 @@ podSecurityContext: {}
 securityContext:
   runAsNonRoot: true
 
+extraEnvVars: []
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
This PR sends charts to `registry.stormforge.io` which now becomes the source of truth for published charts (all existing charts have already been pushed to the new location using the same approach used in the release workflow—`cm-push`).

It also creates a new version of the Live chart with an updated `values.yaml` that accounts for updates to the `stormforge generate secret -o helm` output.