### PR TITLE
Add a values.schema.json

### DIFF
--- a/charts/optimize-live/Chart.yaml
+++ b/charts/optimize-live/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.6"
+appVersion: "0.0.7"
 icon: https://app.stormforge.io/img/logo.png
 home: https://www.stormforge.io/
 maintainers:

--- a/charts/optimize-live/templates/deployment.yaml
+++ b/charts/optimize-live/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
             value: {{ .Values.storageClass }}
 {{- end }}
 {{- end }}
-{{- if .Values.storageClass }}
+{{- if .Values.pvcSize }}
 {{- if (ne "" .Values.pvcSize) }}
           - name: TSDB_PVC_SIZE
             value: {{ .Values.pvcSize }}

--- a/charts/optimize-live/templates/role.yaml
+++ b/charts/optimize-live/templates/role.yaml
@@ -91,6 +91,16 @@ rules:
   - update
   - watch
 - apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - optimize.stormforge.io
   resources:
   - lives

--- a/charts/optimize-live/values.schema.json
+++ b/charts/optimize-live/values.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "properties": {
+    "extraEnvVars": {
+      "type": "array",
+      "items": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        }
+      },
+      "x-kubernetes-patch-merge-key": "name",
+      "x-kubernetes-patch-strategy": "merge"
+    }
+  }
+}

--- a/charts/optimize-live/values.yaml
+++ b/charts/optimize-live/values.yaml
@@ -9,11 +9,11 @@ component:
     controller:
       repository: registry.stormforge.io/optimize-live/controller
       pullPolicy: IfNotPresent
-      tag: 0.0.16
+      tag: 0.0.17
     tsdb:
       repository: registry.stormforge.io/optimize-live/tsdb
       pullPolicy: IfNotPresent
-      tag: 0.0.10
+      tag: 0.0.11
     applier:
       repository: registry.stormforge.io/optimize-live/applier
       pullPolicy: IfNotPresent
@@ -21,11 +21,11 @@ component:
     recommender:
       repository: registry.stormforge.io/optimize-live/recommender
       pullPolicy: IfNotPresent
-      tag: 0.2.4
+      tag: 0.2.7
     grafana:
       repository: grafana/grafana-oss
       pullPolicy: IfNotPresent
-      tag: 8.4.6
+      tag: 8.5.3
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
This PR adds a `values.schema.json` file to start describing the `values.yaml` file.

The main reason for this is actually to get the Kubernetes merge extensions configured: the v3 CLI needs to be able to merge values files using Kubernetes YAML manipulation libraries. Without a schema, the extra environment variables will overwrite instead of merge. Originally I was going to bake this into the CLI code base; however I figured as we do more with the Helm charts this would be a good thing to have anyway.