### PR TITLE
Add support for extraEnvs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -62,6 +62,9 @@ authorization:
   issuer: https://api.stormforge.io/
   clientID: ""
   clientSecret: ""
+extraEnvs: []
+# - name: FOO
+#   value: bar
 EOF
 
 # crds/*
@@ -75,6 +78,12 @@ mv "${BUILD_DIR}/apps_v1_deployment_{{ .release.name }}-controller-manager.yaml"
 # templates/secret.yaml
 mv "${BUILD_DIR}/v1_secret_{{ .release.name }}-manager.yaml" \
 	"${CHART_DIR}/${CHART_NAME}/templates/secret.yaml"
+cat << EOF >> "${CHART_DIR}/${CHART_NAME}/templates/secret.yaml"
+  {{- range .Values.extraEnvs }}
+  {{ .name }}: {{ toYaml .value }}
+  {{- end }}
+EOF
+	
 
 # templates/rbac.yaml
 RBAC_TEMPLATE="${CHART_DIR}/${CHART_NAME}/templates/rbac.yaml"

--- a/build.sh
+++ b/build.sh
@@ -73,6 +73,30 @@ extraEnvs: []
 #   value: bar
 EOF
 
+# values.schema.json
+cat <<-EOF > "${CHART_DIR}/${CHART_NAME}/values.schema.json"
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "properties": {
+    "extraEnvs": {
+      "type": "array",
+      "items": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        }
+      },
+      "x-kubernetes-patch-merge-key": "name",
+      "x-kubernetes-patch-strategy": "merge"
+    }
+  }
+}
+EOF
+
 # crds/*
 CRDS_DIR="${CHART_DIR}/${CHART_NAME}/crds"
 for f in "${BUILD_DIR}/"*_*_customresourcedefinition_*; do mv "${f}" "${CRDS_DIR}/${f#*_*_*_}" ; done

--- a/build.sh
+++ b/build.sh
@@ -62,6 +62,12 @@ authorization:
   issuer: https://api.stormforge.io/
   clientID: ""
   clientSecret: ""
+datadog:
+  apiKey:  # <DATADOG_API_KEY>
+  appKey:  # <DATADOG_APP_KEY>
+newrelic:
+  accountID:  # <NEW_RELIC_ACCOUNT_ID>
+  userKey:  # <NEW_RELIC_API_KEY>
 extraEnvs: []
 # - name: FOO
 #   value: bar
@@ -79,6 +85,16 @@ mv "${BUILD_DIR}/apps_v1_deployment_{{ .release.name }}-controller-manager.yaml"
 mv "${BUILD_DIR}/v1_secret_{{ .release.name }}-manager.yaml" \
 	"${CHART_DIR}/${CHART_NAME}/templates/secret.yaml"
 cat << EOF >> "${CHART_DIR}/${CHART_NAME}/templates/secret.yaml"
+  {{- if .Values.datadog.apiKey }}
+  DATADOG_API_KEY: '{{ .Values.datadog.apiKey }}'
+  {{- end }}
+  {{- if .Values.datadog.appKey }}
+  DATADOG_APP_KEY: '{{ .Values.datadog.appKey }}'
+  {{- end }}
+  {{- if and .Values.newrelic.accountID .Values.newrelic.userKey }}
+  NEW_RELIC_ACCOUNT_ID: '{{ .Values.newrelic.accountID }}'
+  NEW_RELIC_API_KEY: '{{ .Values.newrelic.userKey }}'
+  {{- end }}
   {{- range .Values.extraEnvs }}
   {{ .name }}: {{ toYaml .value }}
   {{- end }}


### PR DESCRIPTION
This adds basic support for `.Values.extraEnvs` in the `optimize-controller` chart.

Today you can do this:

```console
$ stormforge config set controller.default.env.HTTP_PROXY http://my.proxy.example
```

When you run `stormforge init` or `stormforge authorize-cluster` or `stormforge generate secret`, the resulting `Secret` will have an `HTTP_PROXY` data field (along with the other authorization specific key/values).

With the Helm chart, you only have `values.yaml` files; without this change, it not possible to add in additional environment variables.

Note, the current Helm equivalent of the above is:

```console
$ helm template optimize-controller --set 'extraEnvs[0].name=HTTP_PROXY' \
    --set 'extraEnvs[0].value=http://my.proxy.example'
```

Which begs the question, "why isn't the `extraEnvs` in the values.yaml `{}` instead of `[]`?" To which I don't have a good answer or alternative.