### PR TITLE
Use konjure format

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,6 +16,9 @@ jobs:
         with:
           # Need to use a PAT so this will trigger the release action
           token: ${{ secrets.BMASTERS_TOKEN }}
+      - name: Install Konjure
+        run: |-
+          brew install thestormforge/tag/konjure
       - name: Build Chart
         env:
           IMAGE_TAG: ${{ github.event.inputs.image_tag }}

--- a/build.sh
+++ b/build.sh
@@ -102,12 +102,10 @@ CRDS_DIR="${CHART_DIR}/${CHART_NAME}/crds"
 for f in "${BUILD_DIR}/"*_*_customresourcedefinition_*; do mv "${f}" "${CRDS_DIR}/${f#*_*_*_}" ; done
 
 # templates/deployment.yaml
-mv "${BUILD_DIR}/apps_v1_deployment_{{ .release.name }}-controller-manager.yaml" \
-	"${CHART_DIR}/${CHART_NAME}/templates/deployment.yaml"
+konjure --format "${BUILD_DIR}/apps_v1_deployment_{{ .release.name }}-controller-manager.yaml" > "${CHART_DIR}/${CHART_NAME}/templates/deployment.yaml"
 
 # templates/secret.yaml
-mv "${BUILD_DIR}/v1_secret_{{ .release.name }}-manager.yaml" \
-	"${CHART_DIR}/${CHART_NAME}/templates/secret.yaml"
+konjure --format "${BUILD_DIR}/v1_secret_{{ .release.name }}-manager.yaml" > "${CHART_DIR}/${CHART_NAME}/templates/secret.yaml"
 cat << EOF >> "${CHART_DIR}/${CHART_NAME}/templates/secret.yaml"
   {{- if .Values.datadog.apiKey }}
   DATADOG_API_KEY: '{{ .Values.datadog.apiKey }}'
@@ -128,14 +126,14 @@ EOF
 # templates/rbac.yaml
 RBAC_TEMPLATE="${CHART_DIR}/${CHART_NAME}/templates/rbac.yaml"
 echo "{{- if .Values.rbac.create -}}" > "${RBAC_TEMPLATE}"
-cat "${BUILD_DIR}/rbac.authorization.k8s.io_v1_clusterrole_{{ .release.name }}-manager-role.yaml" >> "${RBAC_TEMPLATE}"
+konjure --format "${BUILD_DIR}/rbac.authorization.k8s.io_v1_clusterrole_{{ .release.name }}-manager-role.yaml" >> "${RBAC_TEMPLATE}"
 echo "---" >> "${RBAC_TEMPLATE}"
-cat "${BUILD_DIR}/rbac.authorization.k8s.io_v1_clusterrolebinding_{{ .release.name }}-manager-rolebinding.yaml" >> "${RBAC_TEMPLATE}"
+konjure --format "${BUILD_DIR}/rbac.authorization.k8s.io_v1_clusterrolebinding_{{ .release.name }}-manager-rolebinding.yaml" >> "${RBAC_TEMPLATE}"
 echo "{{- if .Values.rbac.bootstrapPermissions }}" >> "${RBAC_TEMPLATE}"
 echo "---" >> "${RBAC_TEMPLATE}"
-cat "${BUILD_DIR}/rbac.authorization.k8s.io_v1_clusterrole_{{ .release.name }}-patching-role.yaml" >> "${RBAC_TEMPLATE}"
+konjure --format "${BUILD_DIR}/rbac.authorization.k8s.io_v1_clusterrole_{{ .release.name }}-patching-role.yaml" >> "${RBAC_TEMPLATE}"
 echo "---" >> "${RBAC_TEMPLATE}"
-cat "${BUILD_DIR}/rbac.authorization.k8s.io_v1_clusterrolebinding_{{ .release.name }}-patching-rolebinding.yaml" >> "${RBAC_TEMPLATE}"
+konjure --format "${BUILD_DIR}/rbac.authorization.k8s.io_v1_clusterrolebinding_{{ .release.name }}-patching-rolebinding.yaml" >> "${RBAC_TEMPLATE}"
 echo "{{- end -}}" >> "${RBAC_TEMPLATE}"
 echo "{{- end -}}" >> "${RBAC_TEMPLATE}"
 

--- a/charts/optimize-controller/values.schema.json
+++ b/charts/optimize-controller/values.schema.json
@@ -1,0 +1,20 @@
+{
+  "": "https://json-schema.org/draft-07/schema#",
+  "properties": {
+    "extraEnvs": {
+      "type": "array",
+      "items": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        }
+      },
+      "x-kubernetes-patch-merge-key": "name",
+      "x-kubernetes-patch-strategy": "merge"
+    }
+  }
+}


### PR DESCRIPTION
This forces the formatting to be correct by using `konjure --format`; this overrides the "dumb" lexicographical field sorting done by Kustomize on the generated resources. The biggest changes are that all the metadata sections will have `name` before `labels` and long lines will no longer be hard wrapped.

Also, I noticed that the build workflow is using `git commit -a` so the new `values.schema.json` file wasn't committed. Since this whole workflow of building a Helm chart using Kustomize is heading straight to `/dev/null`, I'm just going to explicitly add the file and call it a day rather than risk something unintended with `git add`.