### PR TITLE
Fix Optimize Pro Secret

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -108,17 +108,17 @@ konjure --format "${BUILD_DIR}/apps_v1_deployment_{{ .release.name }}-controller
 konjure --format "${BUILD_DIR}/v1_secret_{{ .release.name }}-manager.yaml" > "${CHART_DIR}/${CHART_NAME}/templates/secret.yaml"
 cat << EOF >> "${CHART_DIR}/${CHART_NAME}/templates/secret.yaml"
   {{- if .Values.datadog.apiKey }}
-  DATADOG_API_KEY: '{{ .Values.datadog.apiKey }}'
+  DATADOG_API_KEY: '{{ .Values.datadog.apiKey | b64enc }}'
   {{- end }}
   {{- if .Values.datadog.appKey }}
-  DATADOG_APP_KEY: '{{ .Values.datadog.appKey }}'
+  DATADOG_APP_KEY: '{{ .Values.datadog.appKey | b64enc }}'
   {{- end }}
   {{- if and .Values.newrelic.accountID .Values.newrelic.userKey }}
-  NEW_RELIC_ACCOUNT_ID: '{{ .Values.newrelic.accountID }}'
-  NEW_RELIC_API_KEY: '{{ .Values.newrelic.userKey }}'
+  NEW_RELIC_ACCOUNT_ID: '{{ .Values.newrelic.accountID | b64enc }}'
+  NEW_RELIC_API_KEY: '{{ .Values.newrelic.userKey | b64enc }}'
   {{- end }}
   {{- range .Values.extraEnvs }}
-  {{ .name }}: {{ toYaml .value }}
+  {{ .name }}: '{{ .value | b64enc }}'
   {{- end }}
 EOF
 	

--- a/build.sh
+++ b/build.sh
@@ -68,7 +68,7 @@ datadog:
 newrelic:
   accountID:  # <NEW_RELIC_ACCOUNT_ID>
   userKey:  # <NEW_RELIC_API_KEY>
-extraEnvs: []
+extraEnvVars: []
 # - name: FOO
 #   value: bar
 EOF
@@ -78,7 +78,7 @@ cat <<-EOF > "${CHART_DIR}/${CHART_NAME}/values.schema.json"
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "properties": {
-    "extraEnvs": {
+    "extraEnvVars": {
       "type": "array",
       "items": {
         "properties": {
@@ -117,7 +117,7 @@ cat << EOF >> "${CHART_DIR}/${CHART_NAME}/templates/secret.yaml"
   NEW_RELIC_ACCOUNT_ID: '{{ .Values.newrelic.accountID | b64enc }}'
   NEW_RELIC_API_KEY: '{{ .Values.newrelic.userKey | b64enc }}'
   {{- end }}
-  {{- range .Values.extraEnvs }}
+  {{- range .Values.extraEnvVars }}
   {{ .name }}: '{{ .value | b64enc }}'
   {{- end }}
 EOF


### PR DESCRIPTION
Still iterating on this...

First: I forgot to base64 encode the secret values; so the resulting secrets were invalid.

Second: I named the value `extraEnvs` while Optimize Live is using `extraEnvVars`; life is easier if we use the same conventions in the charts because then stuff like the "grab the existing secret and build a values.yaml" isn't riddled with edge cases.