### PR TITLE
Include explicit setup tasks and trial job image overrides

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -30,6 +30,9 @@ cp "$(git rev-parse --show-toplevel)/src/${CHART_NAME}/kustomization.yaml" "${BU
 stormforge generate install --bootstrap-role > "${BUILD_DIR}/resources.yaml"
 (cd "${BUILD_DIR}" && kustomize build --output ".")
 
+# Additional information from the CLI
+SETUP_TOOLS_IMAGE_REPOSITORY="$(stormforge version --setuptools-image)"
+SETUP_TOOLS_IMAGE_REPOSITORY="${SETUP_TOOLS_IMAGE_REPOSITORY%%:*}"
 
 # Chart.yaml
 cat <<-EOF > "${CHART_DIR}/${CHART_NAME}/Chart.yaml"
@@ -72,6 +75,20 @@ newrelic:
 extraEnvVars: []
 # - name: FOO
 #   value: bar
+setupTasks:
+  image:
+    repository: ${SETUP_TOOLS_IMAGE_REPOSITORY}
+    # Default is the chart appVersion.
+    tag: ""
+trialJobs:
+  perftest:
+    image:
+      repository: thestormforge/optimize-trials
+      tag: v0.0.3-stormforge-perf
+  locust:
+    image:
+      repository: thestormforge/optimize-trials
+      tag: v0.0.3-locust
 EOF
 
 # values.schema.json

--- a/src/optimize-controller/kustomization.yaml
+++ b/src/optimize-controller/kustomization.yaml
@@ -31,6 +31,13 @@ patches:
           - name: manager
             image: '{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}'
             imagePullPolicy: '{{ .Values.image.pullPolicy }}'
+            env:
+            - name: 'DEFAULT_SETUP_IMAGE'
+              value: '{{ .Values.setupTasks.image.repository }}:{{ .Values.setupTasks.image.tag | default .Chart.AppVersion }}'
+            - name: 'OPTIMIZE_TRIALS_STORMFORGE_PERF_IMAGE'
+              value: '{{ .Values.trialJobs.perftest.image.repository }}:{{ .Values.trialJobs.perftest.image.tag }}'
+            - name: 'OPTIMIZE_TRIALS_LOCUST_IMAGE'
+              value: '{{ .Values.trialJobs.locust.image.repository }}:{{ .Values.trialJobs.locust.image.tag }}'
             envFrom:
             - secretRef:
                 name: '{{ .Release.Name }}-manager'


### PR DESCRIPTION
The goal of this PR is raise awareness of what image names are used by the v2 controller in a default configuration; by explicitly overriding the image names to their default values, they can be extracted by automation.