### PR TITLE
Fix optimize-controller Kube version range

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -47,7 +47,7 @@ sources:
 - $(git remote get-url origin)
 icon: https://app.stormforge.io/img/logo.png
 appVersion: ${CHART_VERSION}
-kubeVersion: 1.14.x - 1.21.x
+kubeVersion: 1.14.x-0 - 1.21.x-0
 EOF
 
 # values.yaml


### PR DESCRIPTION
EKS uses a pre-release version (e.g. 1.21.13-eks-84b4fe6) which [isn't accounted for](https://github.com/Masterminds/semver#working-with-prerelease-versions) with the current range.