### PR TITLE
Fix quoting for empty secret values

### DIFF
--- a/charts/optimize-live/templates/secret.yaml
+++ b/charts/optimize-live/templates/secret.yaml
@@ -7,10 +7,10 @@ metadata:
     {{- include "optimize-live.labels" . | nindent 4 }}
   namespace: {{ include "optimize-live.namespace" . }}
 data:
-  STORMFORGE_AUTHORIZATION_CLIENT_ID: {{ .Values.authorization.clientID | b64enc | quote }}
-  STORMFORGE_AUTHORIZATION_CLIENT_SECRET: {{ .Values.authorization.clientSecret | b64enc | quote }}
-  STORMFORGE_SERVER_IDENTIFIER: {{ .Values.stormforge.address | b64enc | quote }}
-  STORMFORGE_SERVER_ISSUER: {{ .Values.authorization.issuer | b64enc | quote }}
+  STORMFORGE_AUTHORIZATION_CLIENT_ID: '{{ .Values.authorization.clientID | b64enc }}'
+  STORMFORGE_AUTHORIZATION_CLIENT_SECRET: '{{ .Values.authorization.clientSecret | b64enc }}'
+  STORMFORGE_SERVER_IDENTIFIER: '{{ .Values.stormforge.address | b64enc }}'
+  STORMFORGE_SERVER_ISSUER: '{{ .Values.authorization.issuer | b64enc }}'
   {{- range .Values.extraEnvVars }}
-  {{ .name }}: {{ .value | b64enc }}
+  {{ .name }}: '{{ .value | b64enc }}'
   {{- end }}


### PR DESCRIPTION
When passing an empty string through the Go Template pipeline `b64enc | quote` the result is an actual empty string, not a quoted empty string (i.e. `x{{ "" | b64enc | quote }}x` evaluates to `xx` and NOT `x""x`); with the current template that means you end up with a default secret like:
```
...
data:
  STORMFORGE_AUTHORIZATION_CLIENT_ID: 
  STORMFORGE_AUTHORIZATION_CLIENT_SECRET: 
  STORMFORGE_SERVER_IDENTIFIER: aHR0cHM6Ly9hcGkuc3Rvcm1mb3JnZS5pby8=
  STORMFORGE_SERVER_ISSUER: aHR0cHM6Ly9hcGkuc3Rvcm1mb3JnZS5pby8=
```
This PR gives you:
```
...
data:
  STORMFORGE_AUTHORIZATION_CLIENT_ID: ''
  STORMFORGE_AUTHORIZATION_CLIENT_SECRET: ''
  STORMFORGE_SERVER_IDENTIFIER: 'aHR0cHM6Ly9hcGkuc3Rvcm1mb3JnZS5pby8='
  STORMFORGE_SERVER_ISSUER: 'aHR0cHM6Ly9hcGkuc3Rvcm1mb3JnZS5pby8='
```