### PR TITLE
feat: OL-807 adding requests/limits to all components

### DIFF
--- a/charts/optimize-live/templates/deployment.yaml
+++ b/charts/optimize-live/templates/deployment.yaml
@@ -98,7 +98,7 @@ spec:
           readinessProbe:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.resources.optimize-live | nindent 12 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/optimize-live/values.yaml
+++ b/charts/optimize-live/values.yaml
@@ -27,6 +27,40 @@ component:
       pullPolicy: IfNotPresent
       tag: 8.5.4
 
+  resources:
+    # Applications with a large number of autoscaling targets may require increased requests
+    # If needing to unset resources, you can use "cpu: null" or "memory: null" in overrides when installing
+    # These resource values most suit a 500-target setup
+    optimize-live:
+      limits:
+        cpu: 250m
+        memory: 500Mi
+      requests:
+        cpu: 150m
+        memory: 150Mi
+    tsdb:
+      limits:
+        cpu: 2500m # CPU peaks during backlog filling
+        memory: 500Mi
+      requests:
+        cpu: 150m
+        memory: 150Mi
+    applier:
+      limits:
+        cpu: 200m
+        memory: 200Mi
+      requests:
+        cpu: 100m
+        memory: 100Mi
+    recommender:
+      limits:
+        cpu: 2000m
+        memory: 4Gi
+      requests:
+        cpu: 100m
+        memory: 2Gi
+    grafana: {}
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
Please see jira OL-807 for more explanation on the first pass of the requests/limits values for tsdb, controller and gauntlet. We ran a 500-target test on AWS and observed the cpu/mem utilization under these circustances. The requests are above the average of utilization.

Signed-off-by: Rafael Brito <rafa@stormforge.io>