### PR TITLE
feat: OL-807 adding requests/limits to all components

### DIFF
--- a/charts/optimize-live/Chart.yaml
+++ b/charts/optimize-live/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/optimize-live/templates/deployment.yaml
+++ b/charts/optimize-live/templates/deployment.yaml
@@ -94,7 +94,7 @@ spec:
           readinessProbe:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.component.resources.controller | nindent 12 }}
           volumeMounts:
           - name: liveconfig
             mountPath: "/live-config.yaml"

--- a/charts/optimize-live/values.yaml
+++ b/charts/optimize-live/values.yaml
@@ -27,11 +27,31 @@ component:
       pullPolicy: IfNotPresent
       tag: 9.1.5
   resources:
-    tsdb: {}
-    applier: {}
+    # Applications with a large number of autoscaling targets may require increased requests
+    # If needing to unset resources, you can use "cpu: null" or "memory: null" in overrides when installing
+    # These resource values most suit a 500-target setup
+    controller:
+      limits:
+        cpu: 250m
+        memory: 500Mi
+      requests:
+        cpu: 150m
+        memory: 150Mi
+    tsdb:
+      limits:
+        cpu: 2500m    # CPU peaks during backlog filling
+        memory: 500Mi
+      requests:
+        cpu: 150m
+        memory: 150Mi
+    applier:
+      limits:
+        cpu: 200m
+        memory: 200Mi
+      requests:
+        cpu: 100m
+        memory: 100Mi
     recommender:
-      # Applications with a large number of autoscaling targets may require increased requests
-      # If needing to unset resources, you can use "cpu: null" or "memory: null" in overrides when installing
       limits:
         cpu: 2000m
         memory: 2Gi


### PR DESCRIPTION
Please see jira OL-807 for more explanation on the first pass of the requests/limits values for tsdb, controller and gauntlet. We ran a 500-target test on AWS and observed the cpu/mem utilization under these circustances. The requests are above the average of utilization.

Signed-off-by: Rafael Brito <rafa@stormforge.io>