### PR TITLE
Use Action instead of Homebrew

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,10 +16,8 @@ jobs:
         with:
           # Need to use a PAT so this will trigger the release action
           token: ${{ secrets.BMASTERS_TOKEN }}
-      - name: Install Konjure
-        run: |-
-          echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
-          /home/linuxbrew/.linuxbrew/bin/brew install thestormforge/tap/konjure
+      - name: Setup Konjure
+        uses: thestormforge/setup-konjure@v1
       - name: Build Chart
         env:
           IMAGE_TAG: ${{ github.event.inputs.image_tag }}


### PR DESCRIPTION
This burnt me trying to get the CLI beta released last week: the GitHub runners pulled Homebrew from the path (so it is installed, but not usable by default: thus the current mess with the paths below). My assumption is that they are eventually going to pull `brew` out of the Linux runners altogether. So, now there is a proper `setup-konjure` action we can use instead.