### PR TITLE
feat: OL-727 grafana installation as part of Helm

### DIFF
--- a/charts/optimize-live/Chart.yaml
+++ b/charts/optimize-live/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/optimize-live/grafana/dashboards/optimize-live-hpa.json
+++ b/charts/optimize-live/grafana/dashboards/optimize-live-hpa.json
@@ -1,0 +1,687 @@
+{
+    "annotations": {
+        "list": [{
+            "builtIn": 1,
+            "datasource": {
+                "type": "datasource",
+                "uid": "grafana"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+                "limit": 100,
+                "matchAny": false,
+                "tags": [],
+                "type": "dashboard"
+            },
+            "type": "dashboard"
+        }]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 5,
+    "iteration": 1656618325259,
+    "links": [],
+    "liveNow": false,
+    "panels": [{
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${application}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "mappings": [],
+                    "max": 1,
+                    "min": 0,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [{
+                            "color": "green",
+                            "value": null
+                        }]
+                    },
+                    "unit": "percentunit"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 0,
+                "y": 0
+            },
+            "id": 5,
+            "options": {
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "showThresholdLabels": false,
+                "showThresholdMarkers": false
+            },
+            "pluginVersion": "",
+            "targets": [{
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "${application}"
+                },
+                "editorMode": "code",
+                "exemplar": false,
+                "expr": "1 - avg(recommendation{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\",metric=\"requests\",cpuRisk=\"$cpuRisk\"}) / avg(requests{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\"})",
+                "format": "time_series",
+                "instant": false,
+                "legendFormat": "__auto",
+                "range": true,
+                "refId": "A"
+            }],
+            "title": "Percentage Savings (CPU)",
+            "type": "gauge"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${application}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [{
+                            "color": "green",
+                            "value": null
+                        }]
+                    },
+                    "unit": "none"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 12,
+                "y": 0
+            },
+            "id": 4,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "value"
+            },
+            "pluginVersion": "",
+            "targets": [{
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${application}"
+                    },
+                    "editorMode": "code",
+                    "exemplar": false,
+                    "expr": "avg(replicas{workload=~\"$workload\",namespace=~\"$namespace\"}) * (\n    avg(requests{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\"}) \n    - \n    avg(recommendation{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\",metric=\"requests\",cpuRisk=\"$cpuRisk\"})\n)",
+                    "format": "time_series",
+                    "instant": false,
+                    "legendFormat": "__auto",
+                    "range": true,
+                    "refId": "A"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${application}"
+                    },
+                    "expr": "",
+                    "hide": false,
+                    "refId": "B"
+                }
+            ],
+            "title": "cpu core-hours saved (per hr)",
+            "type": "stat"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${application}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineStyle": {
+                            "fill": "solid"
+                        },
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": true,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "min": 0,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [{
+                            "color": "green",
+                            "value": null
+                        }]
+                    },
+                    "unit": "none"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 11,
+                "w": 24,
+                "x": 0,
+                "y": 7
+            },
+            "id": 2,
+            "options": {
+                "legend": {
+                    "calcs": [
+                        "lastNotNull",
+                        "max",
+                        "min"
+                    ],
+                    "displayMode": "table",
+                    "placement": "right"
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "pluginVersion": "",
+            "targets": [{
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${application}"
+                    },
+                    "editorMode": "code",
+                    "exemplar": true,
+                    "expr": "max by (workload,namespace,resource) (sum by (workload,namespace,pod,resource) (requests{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\"})) * 1000",
+                    "hide": false,
+                    "interval": "",
+                    "legendFormat": "requests",
+                    "range": true,
+                    "refId": "B"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${application}"
+                    },
+                    "editorMode": "code",
+                    "exemplar": true,
+                    "expr": "sum by (workload,namespace,resource,cpuRisk) (recommendation{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\",metric=\"requests\",cpuRisk=\"$cpuRisk\"}) * 1000",
+                    "hide": false,
+                    "interval": "",
+                    "legendFormat": "recommendation",
+                    "range": true,
+                    "refId": "D"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${application}"
+                    },
+                    "editorMode": "code",
+                    "exemplar": false,
+                    "expr": "avg by (workload,namespace,resource) (sum by (workload,namespace,pod,resource) (usage{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\"})) * 1000",
+                    "hide": false,
+                    "interval": "",
+                    "legendFormat": "usage",
+                    "range": true,
+                    "refId": "C"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${application}"
+                    },
+                    "editorMode": "code",
+                    "expr": "avg by(workload, namespace) (recommendation{metric=\"requests\",workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\",cpuRisk=\"$cpuRisk\"}) * 1000 * avg by (workload, namespace) (recommendation{metric=\"target\",workload=~\"$workload\",namespace=~\"$namespace\",cpuRisk=\"$cpuRisk\"}) / 100 ",
+                    "hide": false,
+                    "legendFormat": "recommended scale point",
+                    "range": true,
+                    "refId": "E"
+                }
+            ],
+            "title": "CPU Recommendations (millicore)",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${application}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "max": 1,
+                    "min": 0,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [{
+                            "color": "green",
+                            "value": null
+                        }]
+                    },
+                    "unit": "percentunit"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 0,
+                "y": 18
+            },
+            "id": 7,
+            "options": {
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "showThresholdLabels": false,
+                "showThresholdMarkers": false
+            },
+            "pluginVersion": "",
+            "targets": [{
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "${application}"
+                },
+                "editorMode": "code",
+                "exemplar": false,
+                "expr": "1 - avg(recommendation{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"memory\",metric=\"requests\",cpuRisk=\"$cpuRisk\"}) / avg(requests{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"memory\",cpuRisk=\"$cpuRisk\"})",
+                "format": "time_series",
+                "instant": false,
+                "legendFormat": "__auto",
+                "range": true,
+                "refId": "A"
+            }],
+            "title": "Percentage Savings (Memory)",
+            "type": "gauge"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${application}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [{
+                            "color": "green",
+                            "value": null
+                        }]
+                    },
+                    "unit": "decbytes"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 12,
+                "y": 18
+            },
+            "id": 8,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "",
+            "targets": [{
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "${application}"
+                },
+                "editorMode": "code",
+                "exemplar": false,
+                "expr": "avg(replicas{workload=~\"$workload\",namespace=~\"$namespace\"}) * (\n    avg(requests{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"memory\"}) \n    - \n    avg(recommendation{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"memory\",metric=\"requests\"})\n)",
+                "format": "time_series",
+                "instant": false,
+                "legendFormat": "__auto",
+                "range": true,
+                "refId": "A"
+            }],
+            "title": "memory megabyte-hour saved (per hr)",
+            "type": "stat"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${application}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineStyle": {
+                            "fill": "solid"
+                        },
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": true,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "min": 0,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [{
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "decbytes"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 11,
+                "w": 24,
+                "x": 0,
+                "y": 25
+            },
+            "id": 9,
+            "options": {
+                "legend": {
+                    "calcs": [
+                        "lastNotNull",
+                        "max",
+                        "min"
+                    ],
+                    "displayMode": "table",
+                    "placement": "right"
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "pluginVersion": "",
+            "targets": [{
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${application}"
+                    },
+                    "editorMode": "code",
+                    "exemplar": true,
+                    "expr": "max by (workload,namespace,resource) (sum by (workload,namespace,pod,resource) (requests{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"memory\"}))",
+                    "hide": false,
+                    "interval": "",
+                    "legendFormat": "requests",
+                    "range": true,
+                    "refId": "B"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${application}"
+                    },
+                    "editorMode": "code",
+                    "exemplar": true,
+                    "expr": "sum by (workload,namespace,resource,memoryRisk) (recommendation{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"memory\",metric=\"requests\",memoryRisk=\"$memoryRisk\"})",
+                    "hide": false,
+                    "interval": "",
+                    "legendFormat": "recommendation",
+                    "range": true,
+                    "refId": "D"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${application}"
+                    },
+                    "editorMode": "code",
+                    "exemplar": true,
+                    "expr": "avg by (workload,namespace,resource) (sum by (workload,namespace,pod,resource) (usage{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"memory\"}))",
+                    "hide": false,
+                    "interval": "",
+                    "legendFormat": "usage",
+                    "range": true,
+                    "refId": "C"
+                }
+            ],
+            "title": "Memory Recommendations",
+            "type": "timeseries"
+        }
+    ],
+    "refresh": false,
+    "schemaVersion": 36,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+        "list": [{
+                "current": {
+                    "selected": false
+                },
+                "hide": 0,
+                "includeAll": false,
+                "label": "Application",
+                "multi": false,
+                "name": "application",
+                "options": [],
+                "query": "prometheus",
+                "queryValue": "",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "type": "datasource"
+            },
+            {
+                "current": {
+                    "selected": false
+                },
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "${application}"
+                },
+                "definition": "label_values(namespace)",
+                "hide": 0,
+                "includeAll": false,
+                "label": "Namespace",
+                "multi": false,
+                "name": "namespace",
+                "options": [],
+                "query": {
+                    "query": "label_values(namespace)",
+                    "refId": "StandardVariableQuery"
+                },
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "current": {
+                    "selected": false
+                },
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "${application}"
+                },
+                "definition": "label_values(workload)",
+                "hide": 0,
+                "includeAll": false,
+                "label": "Workload",
+                "multi": false,
+                "name": "workload",
+                "options": [],
+                "query": {
+                    "query": "label_values(workload)",
+                    "refId": "StandardVariableQuery"
+                },
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "current": {
+                    "selected": false
+                },
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "${application}"
+                },
+                "definition": "label_values(cpuRisk)",
+                "hide": 0,
+                "includeAll": false,
+                "label": "CPU Tolerance",
+                "multi": false,
+                "name": "cpuRisk",
+                "options": [],
+                "query": {
+                    "query": "label_values(cpuRisk)",
+                    "refId": "StandardVariableQuery"
+                },
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "type": "query"
+            },
+            {
+                "current": {
+                    "selected": false
+                },
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "${application}"
+                },
+                "definition": "label_values(memoryRisk)",
+                "hide": 0,
+                "includeAll": false,
+                "label": "Memory Tolerance",
+                "multi": false,
+                "name": "memoryRisk",
+                "options": [],
+                "query": {
+                    "query": "label_values(memoryRisk)",
+                    "refId": "StandardVariableQuery"
+                },
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "type": "query"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-3h",
+        "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "Optimize Live - HPA",
+    "uid": "d_AhnIjnz",
+    "version": 7,
+    "weekStart": ""
+}

--- a/charts/optimize-live/grafana/dashboards/optimize-live-vpa.json
+++ b/charts/optimize-live/grafana/dashboards/optimize-live-vpa.json
@@ -1,0 +1,489 @@
+{
+    "annotations": {
+        "list": [{
+            "builtIn": 1,
+            "datasource": {
+                "type": "datasource",
+                "uid": "grafana"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+                "limit": 100,
+                "matchAny": false,
+                "tags": [],
+                "type": "dashboard"
+            },
+            "type": "dashboard"
+        }]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 4,
+    "iteration": 1654830168322,
+    "links": [],
+    "liveNow": false,
+    "panels": [{
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${application}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineStyle": {
+                            "fill": "solid"
+                        },
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": true,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [{
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "short"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 9,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 2,
+            "options": {
+                "legend": {
+                    "calcs": [
+                        "lastNotNull",
+                        "max",
+                        "min"
+                    ],
+                    "displayMode": "table",
+                    "placement": "right"
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "pluginVersion": "",
+            "targets": [{
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${application}"
+                    },
+                    "exemplar": true,
+                    "expr": "max by (workload,container) (limits{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\",container=~\"$container\"})",
+                    "interval": "",
+                    "legendFormat": "{{ workload }}.{{ container }}  {{ resource }} limits",
+                    "refId": "A"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${application}"
+                    },
+                    "exemplar": true,
+                    "expr": "max by (workload,container) (requests{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\",container=~\"$container\"})",
+                    "hide": false,
+                    "interval": "",
+                    "legendFormat": "{{ workload }}.{{container}} {{ resource }} requests",
+                    "refId": "B"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${application}"
+                    },
+                    "exemplar": true,
+                    "expr": "avg by (workload,container) (usage{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\",container=~\"$container\"})",
+                    "hide": false,
+                    "interval": "",
+                    "legendFormat": "{{ workload }}.{{container}} {{ resource }} usage",
+                    "refId": "C"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${application}"
+                    },
+                    "editorMode": "code",
+                    "exemplar": true,
+                    "expr": "recommendation{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\",candidate=~\"$candidate\",container=~\"$container\",cpuRisk=~\"$cpuRisk\"}",
+                    "hide": false,
+                    "interval": "",
+                    "legendFormat": "{{ workload }}.{{ container }} {{ metric }} {{ cpuRisk }} tolerance",
+                    "range": true,
+                    "refId": "D"
+                }
+            ],
+            "title": "CPU Recommendations",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${application}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": true,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [{
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "decbytes"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 9,
+                "w": 24,
+                "x": 0,
+                "y": 9
+            },
+            "id": 3,
+            "options": {
+                "legend": {
+                    "calcs": [
+                        "lastNotNull",
+                        "max",
+                        "min"
+                    ],
+                    "displayMode": "table",
+                    "placement": "right"
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "pluginVersion": "",
+            "targets": [{
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${application}"
+                    },
+                    "exemplar": true,
+                    "expr": "max by (workload,container) (limits{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"memory\",container=~\"$container\"})",
+                    "interval": "",
+                    "legendFormat": "{{ workload }}.{{ container}} {{ resource }} limits",
+                    "refId": "A"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${application}"
+                    },
+                    "exemplar": true,
+                    "expr": "max by (workload,container) (requests{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"memory\",container=~\"$container\"})",
+                    "hide": false,
+                    "interval": "",
+                    "legendFormat": "{{ workload }}.{{ container}} {{ resource }} requests",
+                    "refId": "B"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${application}"
+                    },
+                    "exemplar": true,
+                    "expr": "avg by (workload,container) (usage{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"memory\",container=~\"$container\"})",
+                    "hide": false,
+                    "interval": "",
+                    "legendFormat": "{{ workload }}.{{ container}} {{ resource }} usage",
+                    "refId": "C"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${application}"
+                    },
+                    "editorMode": "code",
+                    "exemplar": true,
+                    "expr": "max by (workload,container,resource,metric,memoryRisk) (recommendation{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"memory\",candidate=~\"$candidate\",container=~\"$container\",memoryRisk=~\"$memoryRisk\"})",
+                    "hide": false,
+                    "interval": "",
+                    "legendFormat": "{{ workload }}.{{ container}} {{ metric }} {{ memoryRisk }} tolerance",
+                    "range": true,
+                    "refId": "D"
+                }
+            ],
+            "title": "Memory Recommendations",
+            "type": "timeseries"
+        }
+    ],
+    "schemaVersion": 36,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+        "list": [{
+                "current": {
+                    "selected": false
+                },
+                "hide": 0,
+                "includeAll": false,
+                "label": "Application",
+                "multi": false,
+                "name": "application",
+                "options": [],
+                "query": "prometheus",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "type": "datasource"
+            },
+            {
+                "current": {
+                    "selected": false
+                },
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "${application}"
+                },
+                "definition": "label_values(namespace)",
+                "hide": 0,
+                "includeAll": false,
+                "label": "Namespace",
+                "multi": false,
+                "name": "namespace",
+                "options": [],
+                "query": {
+                    "query": "label_values(namespace)",
+                    "refId": "StandardVariableQuery"
+                },
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "current": {
+                    "selected": false
+                },
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "${application}"
+                },
+                "definition": "label_values(workload)",
+                "hide": 0,
+                "includeAll": false,
+                "label": "Workload",
+                "multi": false,
+                "name": "workload",
+                "options": [],
+                "query": {
+                    "query": "label_values(workload)",
+                    "refId": "StandardVariableQuery"
+                },
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "current": {
+                    "selected": false,
+                    "text": [
+                        "All"
+                    ],
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "${application}"
+                },
+                "definition": "label_values(container)",
+                "hide": 0,
+                "includeAll": true,
+                "label": "Container",
+                "multi": true,
+                "name": "container",
+                "options": [],
+                "query": {
+                    "query": "label_values(container)",
+                    "refId": "StandardVariableQuery"
+                },
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "type": "query"
+            },
+            {
+                "current": {
+                    "selected": false
+                },
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "${application}"
+                },
+                "definition": "label_values(cpuRisk)",
+                "hide": 0,
+                "includeAll": true,
+                "label": "CPU Tolerance",
+                "multi": true,
+                "name": "cpuRisk",
+                "options": [],
+                "query": {
+                    "query": "label_values(cpuRisk)",
+                    "refId": "StandardVariableQuery"
+                },
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "type": "query"
+            },
+            {
+                "current": {
+                    "selected": true
+                },
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "${application}"
+                },
+                "definition": "label_values(memoryRisk)",
+                "hide": 0,
+                "includeAll": true,
+                "label": "Memory Tolerance",
+                "multi": true,
+                "name": "memoryRisk",
+                "options": [],
+                "query": {
+                    "query": "label_values(memoryRisk)",
+                    "refId": "StandardVariableQuery"
+                },
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "type": "query"
+            },
+            {
+                "current": {
+                    "selected": false
+                },
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "${application}"
+                },
+                "definition": "label_values(candidate)",
+                "hide": 0,
+                "includeAll": false,
+                "label": "Recommendation",
+                "multi": false,
+                "name": "candidate",
+                "options": [],
+                "query": {
+                    "query": "label_values(candidate)",
+                    "refId": "StandardVariableQuery"
+                },
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "type": "query"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-6h",
+        "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "Optimize Live - VPA",
+    "uid": "RmIDJNCnk",
+    "version": 4,
+    "weekStart": ""
+}

--- a/charts/optimize-live/grafana/grafana.ini
+++ b/charts/optimize-live/grafana/grafana.ini
@@ -1,0 +1,24 @@
+[analytics]
+reporting_enabled = false
+check_for_updates = false
+
+[auth]
+disable_login_form = true
+
+[auth.anonymous]
+enabled = true
+org_name = Main Org.
+org_role = Viewer
+hide_version = true
+
+[alerting]
+enabled = false
+
+[explore]
+enabled = false
+
+[metrics]
+enabled = false
+
+[expressions]
+enabled = false

--- a/charts/optimize-live/grafana/providers.yaml
+++ b/charts/optimize-live/grafana/providers.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+providers:
+- allowUiUpdates: false
+  disableDeletion: true
+  folder: ""
+  name: Optimize Live
+  options:
+    path: /var/lib/grafana/dashboards
+  orgId: 1
+  type: file
+  updateIntervalSeconds: 10

--- a/charts/optimize-live/templates/_helpers.tpl
+++ b/charts/optimize-live/templates/_helpers.tpl
@@ -103,3 +103,47 @@ Create the namespace name
 {{- define "optimize-live.namespace" -}}
 {{- default .Values.defaultNamespace .Release.Namespace }}
 {{- end }}
+
+{{/*
+Grafana name
+*/}}
+{{- define "grafana.name" -}}
+{{- default "grafana" .Values.component.config.grafana.componentNameOverride }}
+{{- end }}
+
+{{/*
+Grafana Common labels
+*/}}
+{{- define "grafana.labels" -}}
+helm.sh/chart: {{ include "optimize-live.chart" . }}
+{{ include "grafana.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+component: grafana
+{{- end }}
+
+{{/*
+Grafana Selector labels
+*/}}
+{{- define "grafana.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "grafana.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+component: grafana
+{{- end }}
+
+{{/*
+Grafana service port
+*/}}
+{{- define "grafana.servicePort" -}}
+{{- default "80" .Values.component.config.grafana.port }}
+{{- end }}
+
+{{/*
+Grafana service target port
+*/}}
+{{- define "grafana.serviceTargetPort" -}}
+{{- default "3000" .Values.component.config.grafana.targetPort }}
+{{- end }}
+

--- a/charts/optimize-live/templates/grafana/grafana-configmap.yaml
+++ b/charts/optimize-live/templates/grafana/grafana-configmap.yaml
@@ -1,0 +1,11 @@
+{{- if or .Release.IsInstall .Values.component.config.grafana.forceGenerateConfigs }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana
+  labels:
+    {{- include "grafana.labels" . | nindent 4 }}
+  namespace: {{ include "optimize-live.namespace" . }}
+data:
+{{ (.Files.Glob "grafana/grafana.ini").AsConfig | indent 2 }}
+{{- end }}

--- a/charts/optimize-live/templates/grafana/grafana-dashboards-configmap.yaml
+++ b/charts/optimize-live/templates/grafana/grafana-dashboards-configmap.yaml
@@ -1,0 +1,12 @@
+{{- if or .Release.IsInstall .Values.component.config.grafana.forceGenerateConfigs }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboards
+  labels:
+    {{- include "grafana.labels" . | nindent 4 }}
+  namespace: {{ include "optimize-live.namespace" . }}
+data:
+{{ (.Files.Glob "grafana/dashboards/*.json").AsConfig | indent 2 }}
+---
+{{- end }}

--- a/charts/optimize-live/templates/grafana/grafana-datasource-configmap.yaml
+++ b/charts/optimize-live/templates/grafana/grafana-datasource-configmap.yaml
@@ -1,0 +1,21 @@
+{{- if or .Release.IsInstall .Values.component.config.grafana.forceGenerateConfigs }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasource
+  labels:
+    {{- include "grafana.labels" . | nindent 4 }}
+  namespace: {{ include "optimize-live.namespace" . }}
+data:
+  datasource.yaml: |
+    apiVersion: 1
+    datasources:
+    - access: ""
+      editable: false
+      isDefault: false
+      name: "empty"
+      orgId: 1
+      type: prometheus
+      url: {{ .Values.metricsURL }}
+      version: 1
+{{- end }}

--- a/charts/optimize-live/templates/grafana/grafana-deployment.yaml
+++ b/charts/optimize-live/templates/grafana/grafana-deployment.yaml
@@ -1,0 +1,103 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "grafana.name" . }}
+  labels:
+    {{- include "grafana.labels" . | nindent 4 }}
+  namespace: {{ include "optimize-live.namespace" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "grafana.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        configmapChecksum: {{ include (print $.Template.BasePath "/grafana/grafana-configmap.yaml") . | sha256sum }}
+        providersChecksum: {{ include (print $.Template.BasePath "/grafana/grafana-providers-configmap.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "grafana.selectorLabels" . | nindent 8 }}
+        helm.sh/chart-version: {{ .Chart.Version }}
+    spec:
+      enableServiceLinks: false
+      imagePullSecrets:
+        - name: {{ include "optimize-live.fullname" . }}-docker
+      serviceAccountName: {{ include "optimize-live.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ include "grafana.name" . }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: {{ .Values.component.image.grafana.repository }}:{{ .Values.component.image.grafana.tag }}
+          imagePullPolicy: {{ .Values.component.image.grafana.pullPolicy }}
+          livenessProbe:
+            failureThreshold: 10
+            httpGet:
+              path: /api/health
+              port: {{ include "grafana.serviceTargetPort" . }}
+              scheme: HTTP
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 30
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /api/health
+              port: {{ include "grafana.serviceTargetPort" . }}
+              scheme: HTTP
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            {{- toYaml .Values.component.resources.grafana | nindent 12 }}
+          volumeMounts:
+          - mountPath: /etc/grafana/grafana.ini
+            name: grafanaconfig
+            subPath: grafana.ini
+          - mountPath: /var/lib/grafana
+            name: data
+          - mountPath: /etc/grafana/provisioning/dashboards
+            name: grafanaproviders
+          - mountPath: /etc/grafana/provisioning/datasources
+            name: grafanadatasource
+          - mountPath: /var/lib/grafana/dashboards
+            name: grafanadashboards
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: grafana
+        name: grafanaconfig
+      - configMap:
+          defaultMode: 420
+          name: grafana-providers
+        name: grafanaproviders
+      - configMap:
+          defaultMode: 420
+          name: grafana-datasource
+        name: grafanadatasource
+      - configMap:
+          defaultMode: 420
+          name: grafana-dashboards
+        name: grafanadashboards
+      - emptyDir:
+          sizeLimit: 100M
+        name: data
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/optimize-live/templates/grafana/grafana-providers-configmap.yaml
+++ b/charts/optimize-live/templates/grafana/grafana-providers-configmap.yaml
@@ -1,0 +1,11 @@
+{{- if or .Release.IsInstall .Values.component.config.grafana.forceGenerateConfigs }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-providers
+  labels:
+    {{- include "grafana.labels" . | nindent 4 }}
+  namespace: {{ include "optimize-live.namespace" . }}
+data:
+{{ (.Files.Glob "grafana/providers.yaml").AsConfig | indent 2 }}
+{{- end }}

--- a/charts/optimize-live/templates/grafana/grafana-service.yaml
+++ b/charts/optimize-live/templates/grafana/grafana-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "grafana.name" . }}
+  labels:
+    {{- include "grafana.labels" . | nindent 4 }}
+  namespace: {{ include "optimize-live.namespace" . }}
+spec:
+  selector:
+    component: grafana
+  ports:
+    - name: http
+      port: {{ include "grafana.servicePort" . }}
+      protocol: TCP
+      targetPort: {{ include "grafana.serviceTargetPort" . }}
+  type: ClusterIP

--- a/charts/optimize-live/values.yaml
+++ b/charts/optimize-live/values.yaml
@@ -59,6 +59,14 @@ component:
         cpu: 100m
         memory: 100Mi
     grafana: {}
+  config:
+    grafana:
+      componentNameOverride: ""
+      port: "80"
+      targetPort: "3000"
+      # Flag to force the generation of configmap files for Grafana.
+      # Setting as "true" will rewrite configmaps independently if installing or upgrading
+      forceGenerateConfigs: ""
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
This is a (draft for now) PR for OL-727: grafana installation being managed by helm (as opposed to being managed by the controller).
During the optimize-live installation via helm, grafana will be installed as well with an empty data source but with all dashboards and config files.
Upon the creation of the live object, the controller will then configure the correct data source.
During a helm upgrade, grafana configmaps will not be touched.
However, there is a proposed flag `component.config.grafana.forceGenerateConfigs` in case the user wants to reset all grafana configs, including the data sources.

Signed-off-by: Rafael Brito <rafa@stormforge.io>