### PR TITLE
bug: OL-873 increasing tsdb memory limit

### DIFF
--- a/charts/optimize-live/Chart.yaml
+++ b/charts/optimize-live/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/optimize-live/values.yaml
+++ b/charts/optimize-live/values.yaml
@@ -40,7 +40,7 @@ component:
     tsdb:
       limits:
         cpu: 2500m    # CPU peaks during backlog filling
-        memory: 500Mi
+        memory: 1000Mi
       requests:
         cpu: 150m
         memory: 150Mi


### PR DESCRIPTION
After testing more scenarios (datadog as a provider with ~15-30 targets), we see tsdb consuming up to 850Mi of memory. Hence we are increasing the tsdb default limit to 1000Mi to avoid users experiencing OOM kills. 
Signed-off-by: Rafael Brito <rafa@stormforge.io>