### PR TITLE
Feat: OL-727 Grafana component is now part of Helm Chart installation

### DIFF
--- a/charts/optimize-live/grafana/dashboards/optimize-live-hpa.json
+++ b/charts/optimize-live/grafana/dashboards/optimize-live-hpa.json
@@ -1,0 +1,687 @@
+{
+    "annotations": {
+        "list": [{
+            "builtIn": 1,
+            "datasource": {
+                "type": "datasource",
+                "uid": "grafana"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+                "limit": 100,
+                "matchAny": false,
+                "tags": [],
+                "type": "dashboard"
+            },
+            "type": "dashboard"
+        }]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 5,
+    "iteration": 1656618325259,
+    "links": [],
+    "liveNow": false,
+    "panels": [{
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${application}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "mappings": [],
+                    "max": 1,
+                    "min": 0,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [{
+                            "color": "green",
+                            "value": null
+                        }]
+                    },
+                    "unit": "percentunit"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 0,
+                "y": 0
+            },
+            "id": 5,
+            "options": {
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "showThresholdLabels": false,
+                "showThresholdMarkers": false
+            },
+            "pluginVersion": "",
+            "targets": [{
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "${application}"
+                },
+                "editorMode": "code",
+                "exemplar": false,
+                "expr": "1 - avg(recommendation{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\",metric=\"requests\",cpuRisk=\"$cpuRisk\"}) / avg(requests{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\"})",
+                "format": "time_series",
+                "instant": false,
+                "legendFormat": "__auto",
+                "range": true,
+                "refId": "A"
+            }],
+            "title": "Percentage Savings (CPU)",
+            "type": "gauge"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${application}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [{
+                            "color": "green",
+                            "value": null
+                        }]
+                    },
+                    "unit": "none"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 12,
+                "y": 0
+            },
+            "id": 4,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "value"
+            },
+            "pluginVersion": "",
+            "targets": [{
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${application}"
+                    },
+                    "editorMode": "code",
+                    "exemplar": false,
+                    "expr": "avg(replicas{workload=~\"$workload\",namespace=~\"$namespace\"}) * (\n    avg(requests{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\"}) \n    - \n    avg(recommendation{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\",metric=\"requests\",cpuRisk=\"$cpuRisk\"})\n)",
+                    "format": "time_series",
+                    "instant": false,
+                    "legendFormat": "__auto",
+                    "range": true,
+                    "refId": "A"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${application}"
+                    },
+                    "expr": "",
+                    "hide": false,
+                    "refId": "B"
+                }
+            ],
+            "title": "cpu core-hours saved (per hr)",
+            "type": "stat"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${application}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineStyle": {
+                            "fill": "solid"
+                        },
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": true,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "min": 0,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [{
+                            "color": "green",
+                            "value": null
+                        }]
+                    },
+                    "unit": "none"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 11,
+                "w": 24,
+                "x": 0,
+                "y": 7
+            },
+            "id": 2,
+            "options": {
+                "legend": {
+                    "calcs": [
+                        "lastNotNull",
+                        "max",
+                        "min"
+                    ],
+                    "displayMode": "table",
+                    "placement": "right"
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "pluginVersion": "",
+            "targets": [{
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${application}"
+                    },
+                    "editorMode": "code",
+                    "exemplar": true,
+                    "expr": "max by (workload,namespace,resource) (sum by (workload,namespace,pod,resource) (requests{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\"})) * 1000",
+                    "hide": false,
+                    "interval": "",
+                    "legendFormat": "requests",
+                    "range": true,
+                    "refId": "B"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${application}"
+                    },
+                    "editorMode": "code",
+                    "exemplar": true,
+                    "expr": "sum by (workload,namespace,resource,cpuRisk) (recommendation{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\",metric=\"requests\",cpuRisk=\"$cpuRisk\"}) * 1000",
+                    "hide": false,
+                    "interval": "",
+                    "legendFormat": "recommendation",
+                    "range": true,
+                    "refId": "D"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${application}"
+                    },
+                    "editorMode": "code",
+                    "exemplar": false,
+                    "expr": "avg by (workload,namespace,resource) (sum by (workload,namespace,pod,resource) (usage{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\"})) * 1000",
+                    "hide": false,
+                    "interval": "",
+                    "legendFormat": "usage",
+                    "range": true,
+                    "refId": "C"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${application}"
+                    },
+                    "editorMode": "code",
+                    "expr": "avg by(workload, namespace) (recommendation{metric=\"requests\",workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\",cpuRisk=\"$cpuRisk\"}) * 1000 * avg by (workload, namespace) (recommendation{metric=\"target\",workload=~\"$workload\",namespace=~\"$namespace\",cpuRisk=\"$cpuRisk\"}) / 100 ",
+                    "hide": false,
+                    "legendFormat": "recommended scale point",
+                    "range": true,
+                    "refId": "E"
+                }
+            ],
+            "title": "CPU Recommendations (millicore)",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${application}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "max": 1,
+                    "min": 0,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [{
+                            "color": "green",
+                            "value": null
+                        }]
+                    },
+                    "unit": "percentunit"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 0,
+                "y": 18
+            },
+            "id": 7,
+            "options": {
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "showThresholdLabels": false,
+                "showThresholdMarkers": false
+            },
+            "pluginVersion": "",
+            "targets": [{
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "${application}"
+                },
+                "editorMode": "code",
+                "exemplar": false,
+                "expr": "1 - avg(recommendation{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"memory\",metric=\"requests\",cpuRisk=\"$cpuRisk\"}) / avg(requests{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"memory\",cpuRisk=\"$cpuRisk\"})",
+                "format": "time_series",
+                "instant": false,
+                "legendFormat": "__auto",
+                "range": true,
+                "refId": "A"
+            }],
+            "title": "Percentage Savings (Memory)",
+            "type": "gauge"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${application}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [{
+                            "color": "green",
+                            "value": null
+                        }]
+                    },
+                    "unit": "decbytes"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 12,
+                "y": 18
+            },
+            "id": 8,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "",
+            "targets": [{
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "${application}"
+                },
+                "editorMode": "code",
+                "exemplar": false,
+                "expr": "avg(replicas{workload=~\"$workload\",namespace=~\"$namespace\"}) * (\n    avg(requests{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"memory\"}) \n    - \n    avg(recommendation{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"memory\",metric=\"requests\"})\n)",
+                "format": "time_series",
+                "instant": false,
+                "legendFormat": "__auto",
+                "range": true,
+                "refId": "A"
+            }],
+            "title": "memory megabyte-hour saved (per hr)",
+            "type": "stat"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${application}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineStyle": {
+                            "fill": "solid"
+                        },
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": true,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "min": 0,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [{
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "decbytes"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 11,
+                "w": 24,
+                "x": 0,
+                "y": 25
+            },
+            "id": 9,
+            "options": {
+                "legend": {
+                    "calcs": [
+                        "lastNotNull",
+                        "max",
+                        "min"
+                    ],
+                    "displayMode": "table",
+                    "placement": "right"
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "pluginVersion": "",
+            "targets": [{
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${application}"
+                    },
+                    "editorMode": "code",
+                    "exemplar": true,
+                    "expr": "max by (workload,namespace,resource) (sum by (workload,namespace,pod,resource) (requests{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"memory\"}))",
+                    "hide": false,
+                    "interval": "",
+                    "legendFormat": "requests",
+                    "range": true,
+                    "refId": "B"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${application}"
+                    },
+                    "editorMode": "code",
+                    "exemplar": true,
+                    "expr": "sum by (workload,namespace,resource,memoryRisk) (recommendation{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"memory\",metric=\"requests\",memoryRisk=\"$memoryRisk\"})",
+                    "hide": false,
+                    "interval": "",
+                    "legendFormat": "recommendation",
+                    "range": true,
+                    "refId": "D"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${application}"
+                    },
+                    "editorMode": "code",
+                    "exemplar": true,
+                    "expr": "avg by (workload,namespace,resource) (sum by (workload,namespace,pod,resource) (usage{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"memory\"}))",
+                    "hide": false,
+                    "interval": "",
+                    "legendFormat": "usage",
+                    "range": true,
+                    "refId": "C"
+                }
+            ],
+            "title": "Memory Recommendations",
+            "type": "timeseries"
+        }
+    ],
+    "refresh": false,
+    "schemaVersion": 36,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+        "list": [{
+                "current": {
+                    "selected": false
+                },
+                "hide": 0,
+                "includeAll": false,
+                "label": "Application",
+                "multi": false,
+                "name": "application",
+                "options": [],
+                "query": "prometheus",
+                "queryValue": "",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "type": "datasource"
+            },
+            {
+                "current": {
+                    "selected": false
+                },
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "${application}"
+                },
+                "definition": "label_values(namespace)",
+                "hide": 0,
+                "includeAll": false,
+                "label": "Namespace",
+                "multi": false,
+                "name": "namespace",
+                "options": [],
+                "query": {
+                    "query": "label_values(namespace)",
+                    "refId": "StandardVariableQuery"
+                },
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "current": {
+                    "selected": false
+                },
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "${application}"
+                },
+                "definition": "label_values(workload)",
+                "hide": 0,
+                "includeAll": false,
+                "label": "Workload",
+                "multi": false,
+                "name": "workload",
+                "options": [],
+                "query": {
+                    "query": "label_values(workload)",
+                    "refId": "StandardVariableQuery"
+                },
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "current": {
+                    "selected": false
+                },
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "${application}"
+                },
+                "definition": "label_values(cpuRisk)",
+                "hide": 0,
+                "includeAll": false,
+                "label": "CPU Tolerance",
+                "multi": false,
+                "name": "cpuRisk",
+                "options": [],
+                "query": {
+                    "query": "label_values(cpuRisk)",
+                    "refId": "StandardVariableQuery"
+                },
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "type": "query"
+            },
+            {
+                "current": {
+                    "selected": false
+                },
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "${application}"
+                },
+                "definition": "label_values(memoryRisk)",
+                "hide": 0,
+                "includeAll": false,
+                "label": "Memory Tolerance",
+                "multi": false,
+                "name": "memoryRisk",
+                "options": [],
+                "query": {
+                    "query": "label_values(memoryRisk)",
+                    "refId": "StandardVariableQuery"
+                },
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "type": "query"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-3h",
+        "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "Optimize Live - HPA",
+    "uid": "d_AhnIjnz",
+    "version": 7,
+    "weekStart": ""
+}

--- a/charts/optimize-live/grafana/dashboards/optimize-live-hpa.json
+++ b/charts/optimize-live/grafana/dashboards/optimize-live-hpa.json
@@ -1,682 +1,1425 @@
 {
     "annotations": {
-        "list": [{
-            "builtIn": 1,
-            "datasource": {
-                "type": "datasource",
-                "uid": "grafana"
-            },
-            "enable": true,
-            "hide": true,
-            "iconColor": "rgba(0, 211, 255, 1)",
-            "name": "Annotations & Alerts",
-            "target": {
-                "limit": 100,
-                "matchAny": false,
-                "tags": [],
-                "type": "dashboard"
-            },
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "datasource",
+            "uid": "grafana"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "target": {
+            "limit": 100,
+            "matchAny": false,
+            "tags": [],
             "type": "dashboard"
-        }]
+          },
+          "type": "dashboard"
+        }
+      ]
     },
     "editable": true,
     "fiscalYearStartMonth": 0,
     "graphTooltip": 0,
-    "id": 5,
-    "iteration": 1656618325259,
+    "id": 4,
     "links": [],
     "liveNow": false,
-    "panels": [{
-            "datasource": {
-                "type": "prometheus",
-                "uid": "${application}"
-            },
-            "fieldConfig": {
-                "defaults": {
-                    "color": {
-                        "mode": "palette-classic"
-                    },
-                    "mappings": [],
-                    "max": 1,
-                    "min": 0,
-                    "thresholds": {
-                        "mode": "absolute",
-                        "steps": [{
-                            "color": "green",
-                            "value": null
-                        }]
-                    },
-                    "unit": "percentunit"
-                },
-                "overrides": []
-            },
-            "gridPos": {
-                "h": 7,
-                "w": 12,
-                "x": 0,
-                "y": 0
-            },
-            "id": 5,
-            "options": {
-                "orientation": "auto",
-                "reduceOptions": {
-                    "calcs": [
-                        "lastNotNull"
-                    ],
-                    "fields": "",
-                    "values": false
-                },
-                "showThresholdLabels": false,
-                "showThresholdMarkers": false
-            },
-            "pluginVersion": "",
-            "targets": [{
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${application}"
-                },
-                "editorMode": "code",
-                "exemplar": false,
-                "expr": "1 - avg(recommendation{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\",metric=\"requests\",cpuRisk=\"$cpuRisk\"}) / avg(requests{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\"})",
-                "format": "time_series",
-                "instant": false,
-                "legendFormat": "__auto",
-                "range": true,
-                "refId": "A"
-            }],
-            "title": "Percentage Savings (CPU)",
-            "type": "gauge"
+    "panels": [
+      {
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
         },
-        {
-            "datasource": {
-                "type": "prometheus",
-                "uid": "${application}"
+        "description": "",
+        "gridPos": {
+          "h": 4,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "id": 22,
+        "options": {
+          "content": "<div style=\"margin-top:2em;text-align:center;\">\n  <h1 >\n    StormForge Optimize Live\n  </h1>\n  <h3>\n    CPU Recommendations for ${workload}\n  </h3>\n</div>\n",
+          "mode": "html"
+        },
+        "pluginVersion": "",
+        "type": "text"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${application}"
+        },
+        "description": "Currently configured requests and limits, per container. Currently configured HPA target utilization for the workload.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
             },
-            "fieldConfig": {
-                "defaults": {
-                    "color": {
-                        "mode": "thresholds"
-                    },
-                    "mappings": [],
-                    "thresholds": {
-                        "mode": "absolute",
-                        "steps": [{
-                            "color": "green",
-                            "value": null
-                        }]
-                    },
-                    "unit": "none"
-                },
-                "overrides": []
+            "decimals": 3,
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "super-light-red",
+                  "value": null
+                }
+              ]
             },
-            "gridPos": {
-                "h": 7,
-                "w": 12,
-                "x": 12,
-                "y": 0
-            },
-            "id": 4,
-            "options": {
-                "colorMode": "value",
-                "graphMode": "none",
-                "justifyMode": "auto",
-                "orientation": "auto",
-                "reduceOptions": {
-                    "calcs": [
-                        "lastNotNull"
-                    ],
-                    "fields": "",
-                    "values": false
-                },
-                "textMode": "value"
-            },
-            "pluginVersion": "",
-            "targets": [{
-                    "datasource": {
-                        "type": "prometheus",
-                        "uid": "${application}"
-                    },
-                    "editorMode": "code",
-                    "exemplar": false,
-                    "expr": "avg(replicas{workload=~\"$workload\",namespace=~\"$namespace\"}) * (\n    avg(requests{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\"}) \n    - \n    avg(recommendation{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\",metric=\"requests\",cpuRisk=\"$cpuRisk\"})\n)",
-                    "format": "time_series",
-                    "instant": false,
-                    "legendFormat": "__auto",
-                    "range": true,
-                    "refId": "A"
+            "unit": "none"
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byFrameRefID",
+                "options": "HPA Target"
+              },
+              "properties": [
+                {
+                  "id": "decimals"
                 },
                 {
-                    "datasource": {
-                        "type": "prometheus",
-                        "uid": "${application}"
-                    },
-                    "expr": "",
-                    "hide": false,
-                    "refId": "B"
+                  "id": "unit",
+                  "value": "percent"
                 }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 5,
+          "w": 6,
+          "x": 0,
+          "y": 4
+        },
+        "id": 15,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "horizontal",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
             ],
-            "title": "cpu core-hours saved (per hr)",
-            "type": "stat"
+            "fields": "",
+            "values": false
+          },
+          "text": {},
+          "textMode": "value_and_name"
         },
-        {
+        "pluginVersion": "",
+        "targets": [
+          {
             "datasource": {
-                "type": "prometheus",
-                "uid": "${application}"
+              "type": "prometheus",
+              "uid": "${application}"
             },
-            "fieldConfig": {
-                "defaults": {
-                    "color": {
-                        "mode": "palette-classic"
-                    },
-                    "custom": {
-                        "axisLabel": "",
-                        "axisPlacement": "auto",
-                        "barAlignment": 0,
-                        "drawStyle": "line",
-                        "fillOpacity": 10,
-                        "gradientMode": "none",
-                        "hideFrom": {
-                            "legend": false,
-                            "tooltip": false,
-                            "viz": false
-                        },
-                        "lineInterpolation": "linear",
-                        "lineStyle": {
-                            "fill": "solid"
-                        },
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "scaleDistribution": {
-                            "type": "linear"
-                        },
-                        "showPoints": "auto",
-                        "spanNulls": true,
-                        "stacking": {
-                            "group": "A",
-                            "mode": "none"
-                        },
-                        "thresholdsStyle": {
-                            "mode": "off"
-                        }
-                    },
-                    "mappings": [],
-                    "min": 0,
-                    "thresholds": {
-                        "mode": "absolute",
-                        "steps": [{
-                            "color": "green",
-                            "value": null
-                        }]
-                    },
-                    "unit": "none"
-                },
-                "overrides": []
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "avg by (workload,namespace,resource,container) (requests{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\"})",
+            "format": "time_series",
+            "hide": false,
+            "instant": false,
+            "legendFormat": "CPU Requests ({{container}})",
+            "range": true,
+            "refId": "Requests"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${application}"
             },
-            "gridPos": {
-                "h": 11,
-                "w": 24,
-                "x": 0,
-                "y": 7
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "avg by (workload,namespace,resource,container) (limits{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\"})",
+            "format": "time_series",
+            "instant": false,
+            "interval": "",
+            "legendFormat": "CPU Limits ({{container}})",
+            "range": true,
+            "refId": "Limits"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${application}"
             },
-            "id": 2,
-            "options": {
-                "legend": {
-                    "calcs": [
-                        "lastNotNull",
-                        "max",
-                        "min"
-                    ],
-                    "displayMode": "table",
-                    "placement": "right"
-                },
-                "tooltip": {
-                    "mode": "single",
-                    "sort": "none"
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "avg(hpa{namespace=\"$namespace\",metric_name=\"cpu\",metric_target_type=\"utilization\",horizontalpodautoscaler=\"$workload\",application_name=\"$application\"})",
+            "format": "time_series",
+            "hide": false,
+            "instant": false,
+            "interval": "",
+            "legendFormat": "HPA Target",
+            "range": true,
+            "refId": "HPA Target"
+          }
+        ],
+        "title": "Current Settings",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${application}"
+        },
+        "description": "Recommended requests and limits, per container. Recommended HPA target utilization for the workload.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "decimals": 3,
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
                 }
+              ]
             },
-            "pluginVersion": "",
-            "targets": [{
-                    "datasource": {
-                        "type": "prometheus",
-                        "uid": "${application}"
-                    },
-                    "editorMode": "code",
-                    "exemplar": true,
-                    "expr": "max by (workload,namespace,resource) (sum by (workload,namespace,pod,resource) (requests{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\"})) * 1000",
-                    "hide": false,
-                    "interval": "",
-                    "legendFormat": "requests",
-                    "range": true,
-                    "refId": "B"
+            "unit": "none"
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byFrameRefID",
+                "options": "HPA Target"
+              },
+              "properties": [
+                {
+                  "id": "unit",
+                  "value": "percent"
                 },
                 {
-                    "datasource": {
-                        "type": "prometheus",
-                        "uid": "${application}"
-                    },
-                    "editorMode": "code",
-                    "exemplar": true,
-                    "expr": "sum by (workload,namespace,resource,cpuRisk) (recommendation{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\",metric=\"requests\",cpuRisk=\"$cpuRisk\"}) * 1000",
-                    "hide": false,
-                    "interval": "",
-                    "legendFormat": "recommendation",
-                    "range": true,
-                    "refId": "D"
-                },
-                {
-                    "datasource": {
-                        "type": "prometheus",
-                        "uid": "${application}"
-                    },
-                    "editorMode": "code",
-                    "exemplar": false,
-                    "expr": "avg by (workload,namespace,resource) (sum by (workload,namespace,pod,resource) (usage{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\"})) * 1000",
-                    "hide": false,
-                    "interval": "",
-                    "legendFormat": "usage",
-                    "range": true,
-                    "refId": "C"
-                },
-                {
-                    "datasource": {
-                        "type": "prometheus",
-                        "uid": "${application}"
-                    },
-                    "editorMode": "code",
-                    "expr": "avg by(workload, namespace) (recommendation{metric=\"requests\",workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\",cpuRisk=\"$cpuRisk\"}) * 1000 * avg by (workload, namespace) (recommendation{metric=\"target\",workload=~\"$workload\",namespace=~\"$namespace\",cpuRisk=\"$cpuRisk\"}) / 100 ",
-                    "hide": false,
-                    "legendFormat": "recommended scale point",
-                    "range": true,
-                    "refId": "E"
+                  "id": "decimals"
                 }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 5,
+          "w": 6,
+          "x": 6,
+          "y": 4
+        },
+        "id": 14,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "horizontal",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
             ],
-            "title": "CPU Recommendations (millicore)",
-            "type": "timeseries"
+            "fields": "",
+            "values": false
+          },
+          "text": {},
+          "textMode": "value_and_name"
         },
-        {
+        "pluginVersion": "",
+        "targets": [
+          {
             "datasource": {
-                "type": "prometheus",
-                "uid": "${application}"
+              "type": "prometheus",
+              "uid": "${application}"
             },
-            "fieldConfig": {
-                "defaults": {
-                    "color": {
-                        "mode": "thresholds"
-                    },
-                    "mappings": [],
-                    "max": 1,
-                    "min": 0,
-                    "thresholds": {
-                        "mode": "absolute",
-                        "steps": [{
-                            "color": "green",
-                            "value": null
-                        }]
-                    },
-                    "unit": "percentunit"
-                },
-                "overrides": []
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "avg without (candidate) (recommendation{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\",metric=\"requests\",cpuRisk=\"$cpuRisk\"})",
+            "format": "time_series",
+            "hide": false,
+            "instant": false,
+            "interval": "",
+            "legendFormat": "CPU Requests ({{container}})",
+            "range": true,
+            "refId": "Requests"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${application}"
             },
-            "gridPos": {
-                "h": 7,
-                "w": 12,
-                "x": 0,
-                "y": 18
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "avg without (candidate) (recommendation{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\",metric=\"limits\",cpuRisk=\"$cpuRisk\"})",
+            "format": "time_series",
+            "instant": false,
+            "legendFormat": "CPU Limits ({{container}})",
+            "range": true,
+            "refId": "Limits"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${application}"
             },
-            "id": 7,
-            "options": {
-                "orientation": "auto",
-                "reduceOptions": {
-                    "calcs": [
-                        "lastNotNull"
-                    ],
-                    "fields": "",
-                    "values": false
-                },
-                "showThresholdLabels": false,
-                "showThresholdMarkers": false
-            },
-            "pluginVersion": "",
-            "targets": [{
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${application}"
-                },
-                "editorMode": "code",
-                "exemplar": false,
-                "expr": "1 - avg(recommendation{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"memory\",metric=\"requests\",cpuRisk=\"$cpuRisk\"}) / avg(requests{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"memory\",cpuRisk=\"$cpuRisk\"})",
-                "format": "time_series",
-                "instant": false,
-                "legendFormat": "__auto",
-                "range": true,
-                "refId": "A"
-            }],
-            "title": "Percentage Savings (Memory)",
-            "type": "gauge"
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "avg without (candidate) (recommendation{metric=\"target\",workload=~\"$workload\",namespace=~\"$namespace\",cpuRisk=\"$cpuRisk\"})",
+            "format": "time_series",
+            "hide": false,
+            "instant": false,
+            "interval": "",
+            "legendFormat": "HPA Target",
+            "range": true,
+            "refId": "HPA Target"
+          }
+        ],
+        "title": "Recommended Settings",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${application}"
         },
-        {
-            "datasource": {
-                "type": "prometheus",
-                "uid": "${application}"
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
             },
-            "fieldConfig": {
-                "defaults": {
-                    "color": {
-                        "mode": "thresholds"
-                    },
-                    "mappings": [],
-                    "thresholds": {
-                        "mode": "absolute",
-                        "steps": [{
-                            "color": "green",
-                            "value": null
-                        }]
-                    },
-                    "unit": "decbytes"
-                },
-                "overrides": []
-            },
-            "gridPos": {
-                "h": 7,
-                "w": 12,
-                "x": 12,
-                "y": 18
-            },
-            "id": 8,
-            "options": {
-                "colorMode": "value",
-                "graphMode": "none",
-                "justifyMode": "auto",
-                "orientation": "auto",
-                "reduceOptions": {
-                    "calcs": [
-                        "lastNotNull"
-                    ],
-                    "fields": "",
-                    "values": false
-                },
-                "textMode": "auto"
-            },
-            "pluginVersion": "",
-            "targets": [{
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${application}"
-                },
-                "editorMode": "code",
-                "exemplar": false,
-                "expr": "avg(replicas{workload=~\"$workload\",namespace=~\"$namespace\"}) * (\n    avg(requests{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"memory\"}) \n    - \n    avg(recommendation{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"memory\",metric=\"requests\"})\n)",
-                "format": "time_series",
-                "instant": false,
-                "legendFormat": "__auto",
-                "range": true,
-                "refId": "A"
-            }],
-            "title": "memory megabyte-hour saved (per hr)",
-            "type": "stat"
-        },
-        {
-            "datasource": {
-                "type": "prometheus",
-                "uid": "${application}"
-            },
-            "fieldConfig": {
-                "defaults": {
-                    "color": {
-                        "mode": "palette-classic"
-                    },
-                    "custom": {
-                        "axisLabel": "",
-                        "axisPlacement": "auto",
-                        "barAlignment": 0,
-                        "drawStyle": "line",
-                        "fillOpacity": 10,
-                        "gradientMode": "none",
-                        "hideFrom": {
-                            "legend": false,
-                            "tooltip": false,
-                            "viz": false
-                        },
-                        "lineInterpolation": "linear",
-                        "lineStyle": {
-                            "fill": "solid"
-                        },
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "scaleDistribution": {
-                            "type": "linear"
-                        },
-                        "showPoints": "auto",
-                        "spanNulls": true,
-                        "stacking": {
-                            "group": "A",
-                            "mode": "none"
-                        },
-                        "thresholdsStyle": {
-                            "mode": "off"
-                        }
-                    },
-                    "mappings": [],
-                    "min": 0,
-                    "thresholds": {
-                        "mode": "absolute",
-                        "steps": [{
-                                "color": "green",
-                                "value": null
-                            },
-                            {
-                                "color": "red",
-                                "value": 80
-                            }
-                        ]
-                    },
-                    "unit": "decbytes"
-                },
-                "overrides": []
-            },
-            "gridPos": {
-                "h": 11,
-                "w": 24,
-                "x": 0,
-                "y": 25
-            },
-            "id": 9,
-            "options": {
-                "legend": {
-                    "calcs": [
-                        "lastNotNull",
-                        "max",
-                        "min"
-                    ],
-                    "displayMode": "table",
-                    "placement": "right"
-                },
-                "tooltip": {
-                    "mode": "single",
-                    "sort": "none"
-                }
-            },
-            "pluginVersion": "",
-            "targets": [{
-                    "datasource": {
-                        "type": "prometheus",
-                        "uid": "${application}"
-                    },
-                    "editorMode": "code",
-                    "exemplar": true,
-                    "expr": "max by (workload,namespace,resource) (sum by (workload,namespace,pod,resource) (requests{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"memory\"}))",
-                    "hide": false,
-                    "interval": "",
-                    "legendFormat": "requests",
-                    "range": true,
-                    "refId": "B"
-                },
+            "mappings": [],
+            "max": 1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
                 {
-                    "datasource": {
-                        "type": "prometheus",
-                        "uid": "${application}"
-                    },
-                    "editorMode": "code",
-                    "exemplar": true,
-                    "expr": "sum by (workload,namespace,resource,memoryRisk) (recommendation{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"memory\",metric=\"requests\",memoryRisk=\"$memoryRisk\"})",
-                    "hide": false,
-                    "interval": "",
-                    "legendFormat": "recommendation",
-                    "range": true,
-                    "refId": "D"
-                },
-                {
-                    "datasource": {
-                        "type": "prometheus",
-                        "uid": "${application}"
-                    },
-                    "editorMode": "code",
-                    "exemplar": true,
-                    "expr": "avg by (workload,namespace,resource) (sum by (workload,namespace,pod,resource) (usage{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"memory\"}))",
-                    "hide": false,
-                    "interval": "",
-                    "legendFormat": "usage",
-                    "range": true,
-                    "refId": "C"
+                  "color": "green",
+                  "value": null
                 }
+              ]
+            },
+            "unit": "percentunit"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 5,
+          "w": 6,
+          "x": 12,
+          "y": 4
+        },
+        "id": 5,
+        "options": {
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
             ],
-            "title": "Memory Recommendations",
-            "type": "timeseries"
-        }
+            "fields": "",
+            "values": false
+          },
+          "showThresholdLabels": false,
+          "showThresholdMarkers": false
+        },
+        "pluginVersion": "",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${application}"
+            },
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "1 - avg(recommendation{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\",metric=\"requests\",cpuRisk=\"$cpuRisk\"}) / avg(requests{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\"})",
+            "format": "time_series",
+            "instant": false,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Projected CPU Savings",
+        "type": "gauge"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${application}"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "decimals": 3,
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 5,
+          "w": 6,
+          "x": 18,
+          "y": 4
+        },
+        "id": 4,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "value"
+        },
+        "pluginVersion": "",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${application}"
+            },
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "avg(replicas{workload=~\"$workload\",namespace=~\"$namespace\"}) * (\n    avg(requests{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\"}) \n    - \n    avg(recommendation{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\",metric=\"requests\",cpuRisk=\"$cpuRisk\"})\n)",
+            "format": "time_series",
+            "instant": false,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${application}"
+            },
+            "expr": "",
+            "hide": false,
+            "refId": "B"
+          }
+        ],
+        "title": "Projected core-hours savings (per hr)",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${application}"
+        },
+        "description": "Shows the sum total CPU utilization, sum total CPU requests, and sum total projected CPU requests after applying the recommended settings. This view includes and sums totals across all replicas.\n\nRed-shaded area represents over-provisioned requests, and blue-shaded area represents under-provisioned requests, relative to Optimize Live's recommendations.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "Cores",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineStyle": {
+                "fill": "solid"
+              },
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byFrameRefID",
+                "options": "Utilization"
+              },
+              "properties": [
+                {
+                  "id": "custom.fillOpacity",
+                  "value": 25
+                },
+                {
+                  "id": "color",
+                  "value": {
+                    "fixedColor": "yellow",
+                    "mode": "fixed"
+                  }
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byFrameRefID",
+                "options": "Requests"
+              },
+              "properties": [
+                {
+                  "id": "custom.fillBelowTo",
+                  "value": "Cumulative CPU Requests Projection (recommended settings)"
+                },
+                {
+                  "id": "color",
+                  "value": {
+                    "fixedColor": "red",
+                    "mode": "fixed"
+                  }
+                },
+                {
+                  "id": "custom.fillOpacity",
+                  "value": 15
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byFrameRefID",
+                "options": "Recommended Requests"
+              },
+              "properties": [
+                {
+                  "id": "custom.fillBelowTo",
+                  "value": "Total CPU Requests (All Replicas)"
+                },
+                {
+                  "id": "color",
+                  "value": {
+                    "fixedColor": "blue",
+                    "mode": "fixed"
+                  }
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "Number of Replicas"
+              },
+              "properties": [
+                {
+                  "id": "unit",
+                  "value": "none"
+                },
+                {
+                  "id": "custom.lineStyle",
+                  "value": {
+                    "dash": [
+                      0,
+                      10
+                    ],
+                    "fill": "dot"
+                  }
+                },
+                {
+                  "id": "custom.axisLabel",
+                  "value": "Number of Replicas (dotted line)"
+                },
+                {
+                  "id": "color",
+                  "value": {
+                    "fixedColor": "text",
+                    "mode": "fixed"
+                  }
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byFrameRefID",
+                "options": "Deploy Candidates"
+              },
+              "properties": [
+                {
+                  "id": "custom.showPoints",
+                  "value": "always"
+                }
+              ]
+            },
+            {
+              "__systemRef": "hideSeriesFrom",
+              "matcher": {
+                "id": "byNames",
+                "options": {
+                  "mode": "exclude",
+                  "names": [
+                    "Cumulative CPU Utilization",
+                    "Cumulative CPU Requests (current settings)",
+                    "Cumulative CPU Requests Projection (recommended settings)",
+                    "Number of Replicas"
+                  ],
+                  "prefix": "All except:",
+                  "readOnly": true
+                }
+              },
+              "properties": [
+                {
+                  "id": "custom.hideFrom",
+                  "value": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 11,
+          "w": 24,
+          "x": 0,
+          "y": 9
+        },
+        "id": 11,
+        "options": {
+          "legend": {
+            "calcs": [
+              "lastNotNull",
+              "max",
+              "min"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${application}"
+            },
+            "editorMode": "code",
+            "expr": "avg by (workload,namespace,resource) (sum by (workload,namespace,resource) (usage{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\"}))",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "Cumulative CPU Utilization",
+            "range": true,
+            "refId": "Utilization"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${application}"
+            },
+            "editorMode": "code",
+            "expr": "max by(namespace,workload) (requests{namespace=\"$namespace\",workload=\"$workload\",resource=\"cpu\"}) * max by(namespace,workload) (replicas{namespace=\"$namespace\",workload=\"$workload\"})",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "Cumulative CPU Requests (current settings)",
+            "range": true,
+            "refId": "Requests"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${application}"
+            },
+            "editorMode": "code",
+            "expr": "max by(workload, namespace) (recommendation{metric=\"requests\",workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\",cpuRisk=\"$cpuRisk\"}) * max by (workload, namespace) (replicas{workload=~\"$workload\",namespace=~\"$namespace\"})",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "Cumulative CPU Requests Projection (recommended settings)",
+            "range": true,
+            "refId": "Recommended Requests"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${application}"
+            },
+            "editorMode": "code",
+            "expr": "avg(replicas{workload=~\"$workload\",namespace=~\"$namespace\"})",
+            "hide": false,
+            "legendFormat": "Number of Replicas",
+            "range": true,
+            "refId": "Replicas"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${application}"
+            },
+            "editorMode": "code",
+            "expr": "avg by(workload, namespace) (recommendation{metric=\"requests\",workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\",cpuRisk=\"$cpuRisk\"}) * avg by (workload, namespace) ((recommendation{metric=\"target\",workload=~\"$workload\",namespace=~\"$namespace\",cpuRisk=\"$cpuRisk\"}) / 100) * max by (workload, namespace) (replicas{workload=~\"$workload\",namespace=~\"$namespace\"})",
+            "hide": true,
+            "legendFormat": "Projected Utilization",
+            "range": true,
+            "refId": "Projected Utilization"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${application}"
+            },
+            "editorMode": "code",
+            "expr": "avg by (workload,namespace,resource) (sum by (workload,namespace,resource) (requests{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\"}))",
+            "hide": true,
+            "legendFormat": "Total Requests Across Replicas",
+            "range": true,
+            "refId": "Requests (Actual)"
+          }
+        ],
+        "title": "Cumulative Utilization and Requests (CPU)",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "description": "",
+        "gridPos": {
+          "h": 3,
+          "w": 24,
+          "x": 0,
+          "y": 20
+        },
+        "id": 29,
+        "options": {
+          "content": "<div style=\"margin-top:2em;text-align:center;\">\n  <h3>\n    Memory Recommendations for ${workload}\n  </h3>\n</div>",
+          "mode": "html"
+        },
+        "pluginVersion": "",
+        "type": "text"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${application}"
+        },
+        "description": "Currently configured requests and limits, per container.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "super-light-red",
+                  "value": null
+                }
+              ]
+            },
+            "unit": "decbytes"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 6,
+          "x": 0,
+          "y": 23
+        },
+        "id": 27,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "horizontal",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "text": {},
+          "textMode": "value_and_name"
+        },
+        "pluginVersion": "",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${application}"
+            },
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "avg by (workload,namespace,resource,container) (requests{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"memory\"})",
+            "format": "time_series",
+            "hide": false,
+            "instant": false,
+            "legendFormat": "Memory Requests ({{container}})",
+            "range": true,
+            "refId": "Requests"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${application}"
+            },
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "avg by (workload,namespace,resource,container) (limits{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"memory\"})",
+            "format": "time_series",
+            "instant": false,
+            "legendFormat": "Memory Limits ({{container}})",
+            "range": true,
+            "refId": "Limits"
+          }
+        ],
+        "title": "Current Settings",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${application}"
+        },
+        "description": "Recommended requests and limits, per container.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "blue",
+                  "value": null
+                }
+              ]
+            },
+            "unit": "decbytes"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 6,
+          "x": 6,
+          "y": 23
+        },
+        "id": 28,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "horizontal",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "text": {},
+          "textMode": "value_and_name"
+        },
+        "pluginVersion": "",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${application}"
+            },
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "avg without (candidate) (recommendation{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"memory\",metric=\"requests\",cpuRisk=\"$cpuRisk\"})",
+            "format": "time_series",
+            "hide": false,
+            "instant": false,
+            "interval": "",
+            "legendFormat": "Memory Requests ({{container}})",
+            "range": true,
+            "refId": "Requests"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${application}"
+            },
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "avg without (candidate) (recommendation{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"memory\",metric=\"limits\",cpuRisk=\"$cpuRisk\"})",
+            "format": "time_series",
+            "instant": false,
+            "interval": "",
+            "legendFormat": "Memory Limits ({{container}})",
+            "range": true,
+            "refId": "Limits"
+          }
+        ],
+        "title": "Recommended Settings",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${application}"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "max": 1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            },
+            "unit": "percentunit"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 6,
+          "x": 12,
+          "y": 23
+        },
+        "id": 7,
+        "options": {
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showThresholdLabels": false,
+          "showThresholdMarkers": false
+        },
+        "pluginVersion": "",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${application}"
+            },
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "1 - avg(recommendation{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"memory\",metric=\"requests\",cpuRisk=\"$cpuRisk\"}) / avg(requests{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"memory\"})",
+            "format": "time_series",
+            "instant": false,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Projected Savings (Memory)",
+        "type": "gauge"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${application}"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                }
+              ]
+            },
+            "unit": "decbytes"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 6,
+          "x": 18,
+          "y": 23
+        },
+        "id": 8,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "pluginVersion": "",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${application}"
+            },
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "avg(replicas{workload=~\"$workload\",namespace=~\"$namespace\"}) * (\n    avg(requests{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"memory\"}) \n    - \n    avg(recommendation{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"memory\",metric=\"requests\"})\n)",
+            "format": "time_series",
+            "instant": false,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Projected byte-hours savings (per hr)",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${application}"
+        },
+        "description": "Shows the sum total memory utilization, sum total memory requests, and sum total projected memory requests after applying the recommended settings. This view includes and sums totals across all replicas.\n\nRed-shaded area represents over-provisioned requests, and blue-shaded area represents under-provisioned requests, relative to Optimize Live's recommendations.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "Bytes",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "linear",
+              "lineStyle": {
+                "fill": "solid"
+              },
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": true,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            },
+            "unit": "decbytes"
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byFrameRefID",
+                "options": "Utilization"
+              },
+              "properties": [
+                {
+                  "id": "custom.fillOpacity",
+                  "value": 25
+                },
+                {
+                  "id": "color",
+                  "value": {
+                    "fixedColor": "yellow",
+                    "mode": "fixed"
+                  }
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byFrameRefID",
+                "options": "Requests"
+              },
+              "properties": [
+                {
+                  "id": "custom.fillBelowTo",
+                  "value": "Cumulative Memory Requests Projection (recommended settings)"
+                },
+                {
+                  "id": "color",
+                  "value": {
+                    "fixedColor": "red",
+                    "mode": "fixed"
+                  }
+                },
+                {
+                  "id": "custom.fillOpacity",
+                  "value": 15
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byFrameRefID",
+                "options": "Recommended Requests"
+              },
+              "properties": [
+                {
+                  "id": "custom.fillBelowTo",
+                  "value": "Total Memory Requests (All Replicas)"
+                },
+                {
+                  "id": "color",
+                  "value": {
+                    "fixedColor": "blue",
+                    "mode": "fixed"
+                  }
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "Number of Replicas"
+              },
+              "properties": [
+                {
+                  "id": "unit",
+                  "value": "none"
+                },
+                {
+                  "id": "custom.axisLabel",
+                  "value": "Number of Replicas (dotted line)"
+                },
+                {
+                  "id": "custom.lineStyle",
+                  "value": {
+                    "dash": [
+                      0,
+                      10
+                    ],
+                    "fill": "dot"
+                  }
+                },
+                {
+                  "id": "color",
+                  "value": {
+                    "fixedColor": "text",
+                    "mode": "fixed"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 12,
+          "w": 24,
+          "x": 0,
+          "y": 27
+        },
+        "id": 9,
+        "options": {
+          "legend": {
+            "calcs": [
+              "lastNotNull",
+              "max",
+              "min"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${application}"
+            },
+            "editorMode": "code",
+            "exemplar": true,
+            "expr": "avg by (workload,namespace,resource) (sum by (workload,namespace,resource) (usage{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"memory\"}))",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "Cumulative Memory Utilization",
+            "range": true,
+            "refId": "Utilization"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${application}"
+            },
+            "editorMode": "code",
+            "exemplar": true,
+            "expr": "avg by(workload,namespace) (requests{namespace=\"$namespace\",workload=\"$workload\",resource=\"memory\"}) * max by(namespace,workload) (replicas{namespace=\"$namespace\",workload=\"$workload\"})",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "Cumulative Memory Requests (current settings)",
+            "range": true,
+            "refId": "Requests"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${application}"
+            },
+            "editorMode": "code",
+            "exemplar": true,
+            "expr": "max by(workload, namespace) (recommendation{metric=\"requests\",workload=~\"$workload\",namespace=~\"$namespace\",resource=\"memory\",memoryRisk=\"$memoryRisk\"}) * max by (workload, namespace) (replicas{workload=~\"$workload\",namespace=~\"$namespace\"})",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "Cumulative Memory Requests Projection (recommended settings)",
+            "range": true,
+            "refId": "Recommended Requests"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${application}"
+            },
+            "editorMode": "code",
+            "expr": "avg(replicas{workload=~\"$workload\",namespace=~\"$namespace\"})",
+            "hide": false,
+            "legendFormat": "Number of Replicas",
+            "range": true,
+            "refId": "Replicas"
+          }
+        ],
+        "title": "Cumulative Utilization and Requests (Memory)",
+        "type": "timeseries"
+      }
     ],
     "refresh": false,
-    "schemaVersion": 36,
+    "schemaVersion": 37,
     "style": "dark",
     "tags": [],
     "templating": {
-        "list": [{
-                "current": {
-                    "selected": false
-                },
-                "hide": 0,
-                "includeAll": false,
-                "label": "Application",
-                "multi": false,
-                "name": "application",
-                "options": [],
-                "query": "prometheus",
-                "queryValue": "",
-                "refresh": 2,
-                "regex": "",
-                "skipUrlSync": false,
-                "type": "datasource"
-            },
-            {
-                "current": {
-                    "selected": false
-                },
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${application}"
-                },
-                "definition": "label_values(namespace)",
-                "hide": 0,
-                "includeAll": false,
-                "label": "Namespace",
-                "multi": false,
-                "name": "namespace",
-                "options": [],
-                "query": {
-                    "query": "label_values(namespace)",
-                    "refId": "StandardVariableQuery"
-                },
-                "refresh": 2,
-                "regex": "",
-                "skipUrlSync": false,
-                "sort": 1,
-                "tagValuesQuery": "",
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
-            },
-            {
-                "current": {
-                    "selected": false
-                },
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${application}"
-                },
-                "definition": "label_values(workload)",
-                "hide": 0,
-                "includeAll": false,
-                "label": "Workload",
-                "multi": false,
-                "name": "workload",
-                "options": [],
-                "query": {
-                    "query": "label_values(workload)",
-                    "refId": "StandardVariableQuery"
-                },
-                "refresh": 2,
-                "regex": "",
-                "skipUrlSync": false,
-                "sort": 1,
-                "tagValuesQuery": "",
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
-            },
-            {
-                "current": {
-                    "selected": false
-                },
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${application}"
-                },
-                "definition": "label_values(cpuRisk)",
-                "hide": 0,
-                "includeAll": false,
-                "label": "CPU Tolerance",
-                "multi": false,
-                "name": "cpuRisk",
-                "options": [],
-                "query": {
-                    "query": "label_values(cpuRisk)",
-                    "refId": "StandardVariableQuery"
-                },
-                "refresh": 2,
-                "regex": "",
-                "skipUrlSync": false,
-                "sort": 1,
-                "type": "query"
-            },
-            {
-                "current": {
-                    "selected": false
-                },
-                "datasource": {
-                    "type": "prometheus",
-                    "uid": "${application}"
-                },
-                "definition": "label_values(memoryRisk)",
-                "hide": 0,
-                "includeAll": false,
-                "label": "Memory Tolerance",
-                "multi": false,
-                "name": "memoryRisk",
-                "options": [],
-                "query": {
-                    "query": "label_values(memoryRisk)",
-                    "refId": "StandardVariableQuery"
-                },
-                "refresh": 2,
-                "regex": "",
-                "skipUrlSync": false,
-                "sort": 1,
-                "type": "query"
-            }
-        ]
+      "list": [
+        {
+          "current": {
+            "selected": false,
+            "text": "HPA Demo",
+            "value": "HPA Demo"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "label": "Application",
+          "multi": false,
+          "name": "application",
+          "options": [],
+          "query": "prometheus",
+          "queryValue": "",
+          "refresh": 2,
+          "regex": "",
+          "skipUrlSync": false,
+          "type": "datasource"
+        },
+        {
+          "current": {
+            "selected": false,
+            "text": "demo-hpa",
+            "value": "demo-hpa"
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${application}"
+          },
+          "definition": "label_values(namespace)",
+          "hide": 0,
+          "includeAll": false,
+          "label": "Namespace",
+          "multi": false,
+          "name": "namespace",
+          "options": [],
+          "query": {
+            "query": "label_values(namespace)",
+            "refId": "StandardVariableQuery"
+          },
+          "refresh": 2,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 1,
+          "tagValuesQuery": "",
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        },
+        {
+          "current": {
+            "selected": false,
+            "text": "frontend",
+            "value": "frontend"
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${application}"
+          },
+          "definition": "label_values(workload)",
+          "hide": 0,
+          "includeAll": false,
+          "label": "Workload",
+          "multi": false,
+          "name": "workload",
+          "options": [],
+          "query": {
+            "query": "label_values(workload)",
+            "refId": "StandardVariableQuery"
+          },
+          "refresh": 2,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 1,
+          "tagValuesQuery": "",
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        },
+        {
+          "current": {
+            "selected": false,
+            "text": "high",
+            "value": "high"
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${application}"
+          },
+          "definition": "label_values(cpuRisk)",
+          "hide": 0,
+          "includeAll": false,
+          "label": "CPU Tolerance",
+          "multi": false,
+          "name": "cpuRisk",
+          "options": [],
+          "query": {
+            "query": "label_values(cpuRisk)",
+            "refId": "StandardVariableQuery"
+          },
+          "refresh": 2,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 1,
+          "type": "query"
+        },
+        {
+          "current": {
+            "selected": false,
+            "text": "low",
+            "value": "low"
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${application}"
+          },
+          "definition": "label_values(memoryRisk)",
+          "hide": 0,
+          "includeAll": false,
+          "label": "Memory Tolerance",
+          "multi": false,
+          "name": "memoryRisk",
+          "options": [],
+          "query": {
+            "query": "label_values(memoryRisk)",
+            "refId": "StandardVariableQuery"
+          },
+          "refresh": 2,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 1,
+          "type": "query"
+        }
+      ]
     },
     "time": {
-        "from": "now-3h",
-        "to": "now"
+      "from": "now-3h",
+      "to": "now"
     },
     "timepicker": {},
     "timezone": "",
@@ -684,4 +1427,4 @@
     "uid": "d_AhnIjnz",
     "version": 7,
     "weekStart": ""
-}
+  }

--- a/charts/optimize-live/grafana/dashboards/optimize-live-vpa.json
+++ b/charts/optimize-live/grafana/dashboards/optimize-live-vpa.json
@@ -1,0 +1,489 @@
+{
+    "annotations": {
+        "list": [{
+            "builtIn": 1,
+            "datasource": {
+                "type": "datasource",
+                "uid": "grafana"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+                "limit": 100,
+                "matchAny": false,
+                "tags": [],
+                "type": "dashboard"
+            },
+            "type": "dashboard"
+        }]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 4,
+    "iteration": 1654830168322,
+    "links": [],
+    "liveNow": false,
+    "panels": [{
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${application}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineStyle": {
+                            "fill": "solid"
+                        },
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": true,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [{
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "short"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 9,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 2,
+            "options": {
+                "legend": {
+                    "calcs": [
+                        "lastNotNull",
+                        "max",
+                        "min"
+                    ],
+                    "displayMode": "table",
+                    "placement": "right"
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "pluginVersion": "",
+            "targets": [{
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${application}"
+                    },
+                    "exemplar": true,
+                    "expr": "max by (workload,container) (limits{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\",container=~\"$container\"})",
+                    "interval": "",
+                    "legendFormat": "{{ workload }}.{{ container }}  {{ resource }} limits",
+                    "refId": "A"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${application}"
+                    },
+                    "exemplar": true,
+                    "expr": "max by (workload,container) (requests{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\",container=~\"$container\"})",
+                    "hide": false,
+                    "interval": "",
+                    "legendFormat": "{{ workload }}.{{container}} {{ resource }} requests",
+                    "refId": "B"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${application}"
+                    },
+                    "exemplar": true,
+                    "expr": "avg by (workload,container) (usage{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\",container=~\"$container\"})",
+                    "hide": false,
+                    "interval": "",
+                    "legendFormat": "{{ workload }}.{{container}} {{ resource }} usage",
+                    "refId": "C"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${application}"
+                    },
+                    "editorMode": "code",
+                    "exemplar": true,
+                    "expr": "recommendation{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"cpu\",candidate=~\"$candidate\",container=~\"$container\",cpuRisk=~\"$cpuRisk\"}",
+                    "hide": false,
+                    "interval": "",
+                    "legendFormat": "{{ workload }}.{{ container }} {{ metric }} {{ cpuRisk }} tolerance",
+                    "range": true,
+                    "refId": "D"
+                }
+            ],
+            "title": "CPU Recommendations",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "${application}"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 10,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "never",
+                        "spanNulls": true,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [{
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "decbytes"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 9,
+                "w": 24,
+                "x": 0,
+                "y": 9
+            },
+            "id": 3,
+            "options": {
+                "legend": {
+                    "calcs": [
+                        "lastNotNull",
+                        "max",
+                        "min"
+                    ],
+                    "displayMode": "table",
+                    "placement": "right"
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "pluginVersion": "",
+            "targets": [{
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${application}"
+                    },
+                    "exemplar": true,
+                    "expr": "max by (workload,container) (limits{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"memory\",container=~\"$container\"})",
+                    "interval": "",
+                    "legendFormat": "{{ workload }}.{{ container}} {{ resource }} limits",
+                    "refId": "A"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${application}"
+                    },
+                    "exemplar": true,
+                    "expr": "max by (workload,container) (requests{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"memory\",container=~\"$container\"})",
+                    "hide": false,
+                    "interval": "",
+                    "legendFormat": "{{ workload }}.{{ container}} {{ resource }} requests",
+                    "refId": "B"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${application}"
+                    },
+                    "exemplar": true,
+                    "expr": "avg by (workload,container) (usage{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"memory\",container=~\"$container\"})",
+                    "hide": false,
+                    "interval": "",
+                    "legendFormat": "{{ workload }}.{{ container}} {{ resource }} usage",
+                    "refId": "C"
+                },
+                {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "${application}"
+                    },
+                    "editorMode": "code",
+                    "exemplar": true,
+                    "expr": "max by (workload,container,resource,metric,memoryRisk) (recommendation{workload=~\"$workload\",namespace=~\"$namespace\",resource=\"memory\",candidate=~\"$candidate\",container=~\"$container\",memoryRisk=~\"$memoryRisk\"})",
+                    "hide": false,
+                    "interval": "",
+                    "legendFormat": "{{ workload }}.{{ container}} {{ metric }} {{ memoryRisk }} tolerance",
+                    "range": true,
+                    "refId": "D"
+                }
+            ],
+            "title": "Memory Recommendations",
+            "type": "timeseries"
+        }
+    ],
+    "schemaVersion": 36,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+        "list": [{
+                "current": {
+                    "selected": false
+                },
+                "hide": 0,
+                "includeAll": false,
+                "label": "Application",
+                "multi": false,
+                "name": "application",
+                "options": [],
+                "query": "prometheus",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "type": "datasource"
+            },
+            {
+                "current": {
+                    "selected": false
+                },
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "${application}"
+                },
+                "definition": "label_values(namespace)",
+                "hide": 0,
+                "includeAll": false,
+                "label": "Namespace",
+                "multi": false,
+                "name": "namespace",
+                "options": [],
+                "query": {
+                    "query": "label_values(namespace)",
+                    "refId": "StandardVariableQuery"
+                },
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "current": {
+                    "selected": false
+                },
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "${application}"
+                },
+                "definition": "label_values(workload)",
+                "hide": 0,
+                "includeAll": false,
+                "label": "Workload",
+                "multi": false,
+                "name": "workload",
+                "options": [],
+                "query": {
+                    "query": "label_values(workload)",
+                    "refId": "StandardVariableQuery"
+                },
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "current": {
+                    "selected": false,
+                    "text": [
+                        "All"
+                    ],
+                    "value": [
+                        "$__all"
+                    ]
+                },
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "${application}"
+                },
+                "definition": "label_values(container)",
+                "hide": 0,
+                "includeAll": true,
+                "label": "Container",
+                "multi": true,
+                "name": "container",
+                "options": [],
+                "query": {
+                    "query": "label_values(container)",
+                    "refId": "StandardVariableQuery"
+                },
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "type": "query"
+            },
+            {
+                "current": {
+                    "selected": false
+                },
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "${application}"
+                },
+                "definition": "label_values(cpuRisk)",
+                "hide": 0,
+                "includeAll": true,
+                "label": "CPU Tolerance",
+                "multi": true,
+                "name": "cpuRisk",
+                "options": [],
+                "query": {
+                    "query": "label_values(cpuRisk)",
+                    "refId": "StandardVariableQuery"
+                },
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "type": "query"
+            },
+            {
+                "current": {
+                    "selected": true
+                },
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "${application}"
+                },
+                "definition": "label_values(memoryRisk)",
+                "hide": 0,
+                "includeAll": true,
+                "label": "Memory Tolerance",
+                "multi": true,
+                "name": "memoryRisk",
+                "options": [],
+                "query": {
+                    "query": "label_values(memoryRisk)",
+                    "refId": "StandardVariableQuery"
+                },
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "type": "query"
+            },
+            {
+                "current": {
+                    "selected": false
+                },
+                "datasource": {
+                    "type": "prometheus",
+                    "uid": "${application}"
+                },
+                "definition": "label_values(candidate)",
+                "hide": 0,
+                "includeAll": false,
+                "label": "Recommendation",
+                "multi": false,
+                "name": "candidate",
+                "options": [],
+                "query": {
+                    "query": "label_values(candidate)",
+                    "refId": "StandardVariableQuery"
+                },
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "type": "query"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-6h",
+        "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "Optimize Live - VPA",
+    "uid": "RmIDJNCnk",
+    "version": 4,
+    "weekStart": ""
+}

--- a/charts/optimize-live/grafana/grafana.ini
+++ b/charts/optimize-live/grafana/grafana.ini
@@ -1,0 +1,24 @@
+[analytics]
+reporting_enabled = false
+check_for_updates = false
+
+[auth]
+disable_login_form = true
+
+[auth.anonymous]
+enabled = true
+org_name = Main Org.
+org_role = Viewer
+hide_version = true
+
+[alerting]
+enabled = false
+
+[explore]
+enabled = false
+
+[metrics]
+enabled = false
+
+[expressions]
+enabled = false

--- a/charts/optimize-live/grafana/providers.yaml
+++ b/charts/optimize-live/grafana/providers.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+providers:
+- allowUiUpdates: false
+  disableDeletion: true
+  folder: ""
+  name: Optimize Live
+  options:
+    path: /var/lib/grafana/dashboards
+  orgId: 1
+  type: file
+  updateIntervalSeconds: 10

--- a/charts/optimize-live/templates/_helpers.tpl
+++ b/charts/optimize-live/templates/_helpers.tpl
@@ -103,3 +103,46 @@ Create the namespace name
 {{- define "optimize-live.namespace" -}}
 {{- default .Values.defaultNamespace .Release.Namespace }}
 {{- end }}
+
+{{/*
+Grafana name
+*/}}
+{{- define "grafana.name" -}}
+{{- default "grafana" .Values.grafana.nameOverride }}
+{{- end }}
+
+{{/*
+Grafana Common labels
+*/}}
+{{- define "grafana.labels" -}}
+helm.sh/chart: {{ include "optimize-live.chart" . }}
+{{ include "grafana.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+component: grafana
+{{- end }}
+
+{{/*
+Grafana Selector labels
+*/}}
+{{- define "grafana.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "grafana.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+component: grafana
+{{- end }}
+
+{{/*
+Grafana service port
+*/}}
+{{- define "grafana.servicePort" -}}
+{{- default "80" .Values.grafana.port }}
+{{- end }}
+
+{{/*
+Grafana service target port
+*/}}
+{{- define "grafana.serviceTargetPort" -}}
+{{- default "3000" .Values.grafana.targetPort }}
+{{- end }}

--- a/charts/optimize-live/templates/_helpers.tpl
+++ b/charts/optimize-live/templates/_helpers.tpl
@@ -40,7 +40,6 @@ helm.sh/chart: {{ include "optimize-live.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-component: controller
 {{- end }}
 
 {{/*
@@ -104,12 +103,6 @@ Create the namespace name
 {{- default .Values.defaultNamespace .Release.Namespace }}
 {{- end }}
 
-{{/*
-Grafana name
-*/}}
-{{- define "grafana.name" -}}
-{{- default "grafana" .Values.grafana.nameOverride }}
-{{- end }}
 
 {{/*
 Grafana Common labels
@@ -121,14 +114,13 @@ helm.sh/chart: {{ include "optimize-live.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-component: grafana
 {{- end }}
 
 {{/*
 Grafana Selector labels
 */}}
 {{- define "grafana.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "grafana.name" . }}
+app.kubernetes.io/name: grafana
 app.kubernetes.io/instance: {{ .Release.Name }}
 component: grafana
 {{- end }}

--- a/charts/optimize-live/templates/deployment.yaml
+++ b/charts/optimize-live/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "optimize-live.labels" . | nindent 4 }}
   namespace: {{ include "optimize-live.namespace" . }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: 1
   selector:
     matchLabels:
       {{- include "optimize-live.selectorLabels" . | nindent 6 }}

--- a/charts/optimize-live/templates/grafana/grafana-configmap.yaml
+++ b/charts/optimize-live/templates/grafana/grafana-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.grafana.enabled (or .Release.IsInstall .Values.grafana.forceGenerateConfigs) }}
+{{- if .Values.grafana.enabled  }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/optimize-live/templates/grafana/grafana-configmap.yaml
+++ b/charts/optimize-live/templates/grafana/grafana-configmap.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.grafana.enabled (or .Release.IsInstall .Values.grafana.forceGenerateConfigs) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana
+  labels:
+    {{- include "grafana.labels" . | nindent 4 }}
+  namespace: {{ include "optimize-live.namespace" . }}
+data:
+{{ (.Files.Glob "grafana/grafana.ini").AsConfig | indent 2 }}
+{{- end }}

--- a/charts/optimize-live/templates/grafana/grafana-dashboards-configmap.yaml
+++ b/charts/optimize-live/templates/grafana/grafana-dashboards-configmap.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.grafana.enabled (or .Release.IsInstall .Values.grafana.forceGenerateConfigs) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboards
+  labels:
+    {{- include "grafana.labels" . | nindent 4 }}
+  namespace: {{ include "optimize-live.namespace" . }}
+data:
+{{ (.Files.Glob "grafana/dashboards/*.json").AsConfig | indent 2 }}
+---
+{{- end }}

--- a/charts/optimize-live/templates/grafana/grafana-dashboards-configmap.yaml
+++ b/charts/optimize-live/templates/grafana/grafana-dashboards-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.grafana.enabled (or .Release.IsInstall .Values.grafana.forceGenerateConfigs) }}
+{{- if .Values.grafana.enabled  }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/optimize-live/templates/grafana/grafana-datasource-configmap.yaml
+++ b/charts/optimize-live/templates/grafana/grafana-datasource-configmap.yaml
@@ -1,10 +1,10 @@
-{{- if and .Values.grafana.enabled .Release.IsInstall }}
+{{- if .Values.grafana.enabled  }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: grafana-datasource
   labels:
-    {{- include "grafana.labels" . | nindent 4 }}
+    component: grafana
   namespace: {{ include "optimize-live.namespace" . }}
 data:
   datasource.yaml: |

--- a/charts/optimize-live/templates/grafana/grafana-datasource-configmap.yaml
+++ b/charts/optimize-live/templates/grafana/grafana-datasource-configmap.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.grafana.enabled .Release.IsInstall }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasource
+  labels:
+    {{- include "grafana.labels" . | nindent 4 }}
+  namespace: {{ include "optimize-live.namespace" . }}
+data:
+  datasource.yaml: |
+    apiVersion: 1
+    datasources:
+    - access: ""
+      editable: false
+      isDefault: false
+      name: "empty"
+      orgId: 1
+      type: prometheus
+      url: {{ .Values.metricsURL }}
+      version: 1
+{{- end }}

--- a/charts/optimize-live/templates/grafana/grafana-deployment.yaml
+++ b/charts/optimize-live/templates/grafana/grafana-deployment.yaml
@@ -2,12 +2,12 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "grafana.name" . }}
+  name: grafana
   labels:
     {{- include "grafana.labels" . | nindent 4 }}
   namespace: {{ include "optimize-live.namespace" . }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: 1
   selector:
     matchLabels:
       {{- include "grafana.selectorLabels" . | nindent 6 }}
@@ -32,7 +32,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ include "grafana.name" . }}
+        - name: grafana
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ .Values.grafana.image.repository }}:{{ .Values.grafana.image.tag }}

--- a/charts/optimize-live/templates/grafana/grafana-deployment.yaml
+++ b/charts/optimize-live/templates/grafana/grafana-deployment.yaml
@@ -1,0 +1,105 @@
+{{- if .Values.grafana.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "grafana.name" . }}
+  labels:
+    {{- include "grafana.labels" . | nindent 4 }}
+  namespace: {{ include "optimize-live.namespace" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "grafana.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        configmapChecksum: {{ include (print $.Template.BasePath "/grafana/grafana-configmap.yaml") . | sha256sum }}
+        providersChecksum: {{ include (print $.Template.BasePath "/grafana/grafana-providers-configmap.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "grafana.selectorLabels" . | nindent 8 }}
+        helm.sh/chart-version: {{ .Chart.Version }}
+    spec:
+      enableServiceLinks: false
+      imagePullSecrets:
+        - name: {{ include "optimize-live.fullname" . }}-docker
+      serviceAccountName: {{ include "optimize-live.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ include "grafana.name" . }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: {{ .Values.grafana.image.repository }}:{{ .Values.grafana.image.tag }}
+          imagePullPolicy: {{ .Values.grafana.image.pullPolicy }}
+          livenessProbe:
+            failureThreshold: 10
+            httpGet:
+              path: /api/health
+              port: {{ include "grafana.serviceTargetPort" . }}
+              scheme: HTTP
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 30
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /api/health
+              port: {{ include "grafana.serviceTargetPort" . }}
+              scheme: HTTP
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            {{- toYaml .Values.grafana.resources | nindent 12 }}
+          volumeMounts:
+          - mountPath: /etc/grafana/grafana.ini
+            name: grafanaconfig
+            subPath: grafana.ini
+          - mountPath: /var/lib/grafana
+            name: data
+          - mountPath: /etc/grafana/provisioning/dashboards
+            name: grafanaproviders
+          - mountPath: /etc/grafana/provisioning/datasources
+            name: grafanadatasource
+          - mountPath: /var/lib/grafana/dashboards
+            name: grafanadashboards
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: grafana
+        name: grafanaconfig
+      - configMap:
+          defaultMode: 420
+          name: grafana-providers
+        name: grafanaproviders
+      - configMap:
+          defaultMode: 420
+          name: grafana-datasource
+        name: grafanadatasource
+      - configMap:
+          defaultMode: 420
+          name: grafana-dashboards
+        name: grafanadashboards
+      - emptyDir:
+          sizeLimit: 100M
+        name: data
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/optimize-live/templates/grafana/grafana-providers-configmap.yaml
+++ b/charts/optimize-live/templates/grafana/grafana-providers-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.grafana.enabled (or .Release.IsInstall .Values.grafana.forceGenerateConfigs) }}
+{{- if .Values.grafana.enabled  }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/optimize-live/templates/grafana/grafana-providers-configmap.yaml
+++ b/charts/optimize-live/templates/grafana/grafana-providers-configmap.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.grafana.enabled (or .Release.IsInstall .Values.grafana.forceGenerateConfigs) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-providers
+  labels:
+    {{- include "grafana.labels" . | nindent 4 }}
+  namespace: {{ include "optimize-live.namespace" . }}
+data:
+{{ (.Files.Glob "grafana/providers.yaml").AsConfig | indent 2 }}
+{{- end }}

--- a/charts/optimize-live/templates/grafana/grafana-service.yaml
+++ b/charts/optimize-live/templates/grafana/grafana-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.grafana.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "grafana.name" . }}
+  labels:
+    {{- include "grafana.labels" . | nindent 4 }}
+  namespace: {{ include "optimize-live.namespace" . }}
+spec:
+  selector:
+    component: grafana
+  ports:
+    - name: http
+      port: {{ include "grafana.servicePort" . }}
+      protocol: TCP
+      targetPort: {{ include "grafana.serviceTargetPort" . }}
+  type: ClusterIP
+{{- end}}

--- a/charts/optimize-live/templates/grafana/grafana-service.yaml
+++ b/charts/optimize-live/templates/grafana/grafana-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "grafana.name" . }}
+  name: grafana
   labels:
     {{- include "grafana.labels" . | nindent 4 }}
   namespace: {{ include "optimize-live.namespace" . }}

--- a/charts/optimize-live/values.yaml
+++ b/charts/optimize-live/values.yaml
@@ -52,9 +52,6 @@ grafana:
   nameOverride: ""
   port: "80"
   targetPort: "3000"
-  # Flag to force the generation of configmap files for Grafana.
-  # Setting as true (without quotes) will rewrite configmaps when upgrading
-  forceGenerateConfigs: false
 
 image:
   repository: registry.stormforge.io/optimize-live/controller

--- a/charts/optimize-live/values.yaml
+++ b/charts/optimize-live/values.yaml
@@ -44,10 +44,17 @@ recommender:
       memory: 100Mi
 
 grafana:
+  enabled: true
   image:
     repository: grafana/grafana-oss
     pullPolicy: IfNotPresent
     tag: 9.1.5
+  nameOverride: ""
+  port: "80"
+  targetPort: "3000"
+  # Flag to force the generation of configmap files for Grafana.
+  # Setting as true (without quotes) will rewrite configmaps when upgrading
+  forceGenerateConfigs: false
 
 image:
   repository: registry.stormforge.io/optimize-live/controller

--- a/charts/optimize-live/values.yaml
+++ b/charts/optimize-live/values.yaml
@@ -2,8 +2,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
-
 tsdb:
   image:
     repository: registry.stormforge.io/optimize-live/tsdb
@@ -49,7 +47,6 @@ grafana:
     repository: grafana/grafana-oss
     pullPolicy: IfNotPresent
     tag: 9.1.5
-  nameOverride: ""
   port: "80"
   targetPort: "3000"
 


### PR DESCRIPTION
Grafana is now part of the Helm Chart 0.6.X installation with config files as part of the helm chart directory structure.
Users can skip Grafana installation setting `grafana.enabled=false`. The Optimize-Live controller configures Grafana data sources when an application is created. 
Signed-off-by: Rafael Brito <rafa@stormforge.io>