### PR TITLE
feat: OL-664 support nodeselector/tolerations/affinity to all components.

### DIFF
--- a/charts/optimize-live/templates/configmap.yaml
+++ b/charts/optimize-live/templates/configmap.yaml
@@ -29,6 +29,19 @@ data:
         resources:
           {{- toYaml .Values.tsdb.resources | nindent 10 }}
         {{- end }}
+        {{- if .Values.tsdb.nodeSelector }}
+        nodeSelector:
+          {{- toYaml .Values.tsdb.nodeSelector | nindent 10 }}
+        {{- end }}
+        {{- if .Values.tsdb.tolerations }}
+        tolerations:
+          {{- toYaml .Values.tsdb.tolerations | nindent 8 }}
+        {{- end }}
+        {{- if .Values.tsdb.affinity }}
+        affinity:
+          {{- toYaml .Values.tsdb.affinity | nindent 10 }}
+        {{- end }}
+    
       applier:
         image: "{{ .Values.applier.image.repository }}:{{ .Values.applier.image.tag }}"
         imagePullPolicy: {{ .Values.applier.image.pullPolicy }}
@@ -36,6 +49,19 @@ data:
         resources:
           {{- toYaml .Values.applier.resources | nindent 10 }}
         {{- end }}
+        {{- if .Values.applier.nodeSelector }}
+        nodeSelector:
+          {{- toYaml .Values.applier.nodeSelector | nindent 10 }}
+        {{- end }}
+        {{- if .Values.applier.tolerations }}
+        tolerations:
+          {{- toYaml .Values.applier.tolerations | nindent 8 }}
+        {{- end }}
+        {{- if .Values.applier.affinity }}
+        affinity:
+          {{- toYaml .Values.applier.affinity | nindent 10 }}
+        {{- end }}
+    
       recommender:
         image: "{{ .Values.recommender.image.repository }}:{{ .Values.recommender.image.tag }}"
         imagePullPolicy: {{ .Values.recommender.image.pullPolicy }}
@@ -43,10 +69,15 @@ data:
         resources:
           {{- toYaml .Values.recommender.resources | nindent 10 }}
         {{- end }}
-      grafana:
-        image: "{{ .Values.grafana.image.repository }}:{{ .Values.grafana.image.tag }}"
-        imagePullPolicy: {{ .Values.grafana.image.pullPolicy }}
-        {{- if .Values.grafana.resources }}
-        resources:
-          {{- toYaml .Values.grafana.resources | nindent 10 }}
+        {{- if .Values.recommender.nodeSelector }}
+        nodeSelector:
+          {{- toYaml .Values.recommender.nodeSelector | nindent 10 }}
+        {{- end }}
+        {{- if .Values.recommender.tolerations }}
+        tolerations:
+          {{- toYaml .Values.recommender.tolerations | nindent 8 }}
+        {{- end }}
+        {{- if .Values.recommender.affinity }}
+        affinity:
+          {{- toYaml .Values.recommender.affinity | nindent 10 }}
         {{- end }}

--- a/charts/optimize-live/templates/deployment.yaml
+++ b/charts/optimize-live/templates/deployment.yaml
@@ -106,5 +106,5 @@ spec:
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/charts/optimize-live/templates/grafana/grafana-deployment.yaml
+++ b/charts/optimize-live/templates/grafana/grafana-deployment.yaml
@@ -90,16 +90,16 @@ spec:
       - emptyDir:
           sizeLimit: 100M
         name: data
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.grafana.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.grafana.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.grafana.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 6 }}
       {{- end }}
 {{- end }}

--- a/charts/optimize-live/values.yaml
+++ b/charts/optimize-live/values.yaml
@@ -14,6 +14,9 @@ tsdb:
     requests:
       cpu: 150m
       memory: 150Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 applier:
   image:
@@ -27,6 +30,9 @@ applier:
     requests:
       cpu: 100m
       memory: 100Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 recommender:
   image:
@@ -40,6 +46,9 @@ recommender:
     requests:
       cpu: 100m
       memory: 100Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 grafana:
   enabled: true
@@ -47,6 +56,9 @@ grafana:
     repository: grafana/grafana-oss
     pullPolicy: IfNotPresent
     tag: 9.1.5
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
   port: "80"
   targetPort: "3000"
 


### PR DESCRIPTION
Please see OL-664 for the result of the testing.
This change adds nodeSelector/tolerations/affinity on the optimize-live configmap for each component (optimize-live controller to actually process the config).
Additionally, in this PR, I fixed the indentation of the optimize-live deployment for the tolerations and I separated the grafana to have its own nodeselector/tolerations/affinity.

Signed-off-by: Rafael Brito <rafa@stormforge.io>