### PR TITLE
Change tooltip mode from single to multi

### DIFF
--- a/charts/optimize-live/grafana/dashboards/optimize-live-hpa.json
+++ b/charts/optimize-live/grafana/dashboards/optimize-live-hpa.json
@@ -596,7 +596,7 @@
             "showLegend": true
           },
           "tooltip": {
-            "mode": "single",
+            "mode": "multi",
             "sort": "none"
           }
         },
@@ -1179,7 +1179,7 @@
             "showLegend": true
           },
           "tooltip": {
-            "mode": "single",
+            "mode": "multi",
             "sort": "none"
           }
         },


### PR DESCRIPTION
This prevents things like the number of replicas from hiding behind other lines, and makes it easy to see all values at a point in time.