### PR TITLE
Update trial image references in the Helm chart

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -84,11 +84,19 @@ trialJobs:
   perftest:
     image:
       repository: thestormforge/optimize-trials
-      tag: v0.0.3-stormforge-perf
+      tag: v0.0.5-stormforge-perf
   locust:
     image:
       repository: thestormforge/optimize-trials
-      tag: v0.0.3-locust
+      tag: v0.0.5-locust
+  k6:
+    image:
+      repository: thestormforge/optimize-trials
+      tag: v0.0.5-k6
+  jmeter:
+    image:
+      repository: thestormforge/optimize-trials
+      tag: v0.0.5-jmeter
 EOF
 
 # values.schema.json

--- a/src/optimize-controller/kustomization.yaml
+++ b/src/optimize-controller/kustomization.yaml
@@ -38,6 +38,10 @@ patches:
               value: '{{ .Values.trialJobs.perftest.image.repository }}:{{ .Values.trialJobs.perftest.image.tag }}'
             - name: 'OPTIMIZE_TRIALS_LOCUST_IMAGE'
               value: '{{ .Values.trialJobs.locust.image.repository }}:{{ .Values.trialJobs.locust.image.tag }}'
+            - name: 'OPTIMIZE_TRIALS_K6_IMAGE'
+              value: '{{ .Values.trialJobs.k6.image.repository }}:{{ .Values.trialJobs.k6.image.tag }}'
+            - name: 'OPTIMIZE_TRIALS_JMETER_IMAGE'
+              value: '{{ .Values.trialJobs.jmeter.image.repository }}:{{ .Values.trialJobs.jmeter.image.tag }}'
             envFrom:
             - secretRef:
                 name: '{{ .Release.Name }}-manager'


### PR DESCRIPTION
Update the references to the optimize-trial images. This will not appear in the Helm chart until the next Optimize Pro 2.x release. Which may be never.