### PR TITLE
fix: remove duplicate label

### DIFF
--- a/charts/optimize-live/Chart.yaml
+++ b/charts/optimize-live/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.3
+version: 0.6.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/optimize-live/templates/_helpers.tpl
+++ b/charts/optimize-live/templates/_helpers.tpl
@@ -40,7 +40,6 @@ helm.sh/chart: {{ include "optimize-live.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-component: controller
 {{- end }}
 
 {{/*


### PR DESCRIPTION
We included component:controller twice, which makes helm template generate invalid yaml, which breaks some GitOps automation (like Flux)