### PR TITLE
Ensure debug is boolean in Opt Live values schema

### DIFF
--- a/charts/optimize-live/values.schema.json
+++ b/charts/optimize-live/values.schema.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "properties": {
+    "debug": {
+      "type": "boolean"
+    },
     "extraEnvVars": {
       "type": "array",
       "items": {
@@ -16,5 +19,6 @@
       "x-kubernetes-patch-merge-key": "name",
       "x-kubernetes-patch-strategy": "merge"
     }
-  }
+  },
+  "additionalProperties": true
 }


### PR DESCRIPTION
This incremental validation addresses a possible user error of setting `{"debug": "false"}`, which due to any string evaluating as boolean true has the same effect as setting `{"debug": true}`.

This commit also adds an explicit `{"additionalProperties": true}` setting, to make it visually clearer to users with less knowledge of json schema that this schema is *very* incomplete in how much it validates.